### PR TITLE
feature : 회원가입/로그인/로그아웃 구현 (이메일 + 구글)

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,5 +1,6 @@
 import { QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
+import AuthSessionProvider from '../features/auth/components/authSessionProvider';
 import { queryClient } from '../shared/lib/queryClient';
 
 type AppProvidersProps = {
@@ -9,7 +10,7 @@ type AppProvidersProps = {
 function AppProviders(props: AppProvidersProps) {
   return (
     <QueryClientProvider client={queryClient}>
-      {props.children}
+      <AuthSessionProvider>{props.children}</AuthSessionProvider>
     </QueryClientProvider>
   );
 }

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,9 +1,24 @@
 import { createBrowserRouter } from 'react-router-dom';
+import AuthCallbackPage from '../features/auth/components/authCallbackPage';
+import SignInPage from '../features/auth/components/signInPage';
+import SignUpPage from '../features/auth/components/signUpPage';
 import HomePage from '../features/browse/components/homePage';
 
 export const router = createBrowserRouter([
   {
     path: '/',
     element: <HomePage />,
+  },
+  {
+    path: '/signup',
+    element: <SignUpPage />,
+  },
+  {
+    path: '/login',
+    element: <SignInPage />,
+  },
+  {
+    path: '/auth/callback',
+    element: <AuthCallbackPage />,
   },
 ]);

--- a/src/features/auth/api/authApi.ts
+++ b/src/features/auth/api/authApi.ts
@@ -1,0 +1,88 @@
+import type { AuthChangeEvent } from '@supabase/supabase-js';
+import { supabase } from '../../../shared/lib/supabaseClient';
+import type { AuthSession, EmailCredentials, SignUpResult } from '../types';
+
+const OAUTH_REDIRECT_PATH = '/auth/callback';
+
+function buildRedirectUrl(): string {
+  return `${window.location.origin}${OAUTH_REDIRECT_PATH}`;
+}
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+/**
+ * 이메일 회원가입. profiles 행은 DB 트리거(handle_new_user)가 자동 생성한다.
+ * 이메일 확인이 켜져 있으면 session이 null로 돌아온다.
+ */
+export async function signUpWithEmail(
+  credentials: EmailCredentials,
+): Promise<SignUpResult> {
+  const { data, error } = await supabase.auth.signUp({
+    email: normalizeEmail(credentials.email),
+    password: credentials.password,
+    options: { emailRedirectTo: buildRedirectUrl() },
+  });
+
+  if (error !== null) {
+    throw error;
+  }
+
+  return { session: data.session, needsEmailConfirm: data.session === null };
+}
+
+export async function signInWithEmail(
+  credentials: EmailCredentials,
+): Promise<AuthSession> {
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email: normalizeEmail(credentials.email),
+    password: credentials.password,
+  });
+
+  if (error !== null) {
+    throw error;
+  }
+
+  return data.session;
+}
+
+/** 구글 OAuth. 성공 시 브라우저가 구글 동의 화면으로 이동하므로 이후 코드는 실행되지 않는다. */
+export async function signInWithGoogle(): Promise<void> {
+  const { error } = await supabase.auth.signInWithOAuth({
+    provider: 'google',
+    options: { redirectTo: buildRedirectUrl() },
+  });
+
+  if (error !== null) {
+    throw error;
+  }
+}
+
+export async function signOut(): Promise<void> {
+  const { error } = await supabase.auth.signOut();
+
+  if (error !== null) {
+    throw error;
+  }
+}
+
+export async function getCurrentSession(): Promise<AuthSession | null> {
+  const { data, error } = await supabase.auth.getSession();
+
+  if (error !== null) {
+    throw error;
+  }
+
+  return data.session;
+}
+
+export function subscribeToAuthChanges(
+  handler: (event: AuthChangeEvent, session: AuthSession | null) => void,
+): () => void {
+  const { data } = supabase.auth.onAuthStateChange(handler);
+
+  return function unsubscribe(): void {
+    data.subscription.unsubscribe();
+  };
+}

--- a/src/features/auth/components/authCallbackPage.tsx
+++ b/src/features/auth/components/authCallbackPage.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { selectAuthStatus, useAuthStore } from '../store/authStore';
+
+/**
+ * 구글 OAuth·이메일 인증 링크의 리다이렉트 착지 지점.
+ * supabase-js가 URL의 토큰을 세션으로 교환하면 useAuthSessionSync가 상태를 갱신하고,
+ * 그 결과에 따라 홈 또는 로그인 화면으로 보낸다.
+ */
+function AuthCallbackPage() {
+  const navigate = useNavigate();
+  const status = useAuthStore(selectAuthStatus);
+
+  useEffect(
+    function redirectWhenSessionResolved() {
+      if (status === 'loading') {
+        return;
+      }
+      navigate(status === 'authenticated' ? '/' : '/login', { replace: true });
+    },
+    [status, navigate],
+  );
+
+  return (
+    <main
+      role="status"
+      className="mx-auto flex min-h-screen max-w-screen-sm flex-col items-center justify-center gap-3 p-6"
+    >
+      <span className="h-8 w-8 animate-spin rounded-full border-2 border-emerald-500 border-t-transparent" />
+      <p className="text-sm text-gray-600 dark:text-gray-400">로그인 처리 중입니다…</p>
+    </main>
+  );
+}
+
+export default AuthCallbackPage;

--- a/src/features/auth/components/authDivider.tsx
+++ b/src/features/auth/components/authDivider.tsx
@@ -1,0 +1,11 @@
+function AuthDivider() {
+  return (
+    <div className="flex items-center gap-3" aria-hidden="true">
+      <span className="h-px flex-1 bg-gray-200 dark:bg-gray-800" />
+      <span className="text-xs text-gray-400 dark:text-gray-500">또는</span>
+      <span className="h-px flex-1 bg-gray-200 dark:bg-gray-800" />
+    </div>
+  );
+}
+
+export default AuthDivider;

--- a/src/features/auth/components/authFormMessage.tsx
+++ b/src/features/auth/components/authFormMessage.tsx
@@ -1,0 +1,25 @@
+type AuthFormMessageProps = {
+  tone: 'error' | 'info';
+  message: string;
+};
+
+const CLASS_BY_TONE: Record<AuthFormMessageProps['tone'], string> = {
+  error:
+    'border-red-300 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-950 dark:text-red-300',
+  info:
+    'border-emerald-300 bg-emerald-50 text-emerald-800 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-300',
+};
+
+/** 폼 전체에 대한 서버 응답 메시지(로그인 실패, 가입 안내 등). */
+function AuthFormMessage(props: AuthFormMessageProps) {
+  return (
+    <p
+      role={props.tone === 'error' ? 'alert' : 'status'}
+      className={`rounded-lg border px-3 py-2 text-sm ${CLASS_BY_TONE[props.tone]}`}
+    >
+      {props.message}
+    </p>
+  );
+}
+
+export default AuthFormMessage;

--- a/src/features/auth/components/authLayout.tsx
+++ b/src/features/auth/components/authLayout.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+
+type AuthLayoutProps = {
+  title: string;
+  description: string;
+  children: ReactNode;
+  footer: ReactNode;
+};
+
+/** 로그인·회원가입 화면의 공통 껍데기(로고, 카드, 하단 안내). */
+function AuthLayout(props: AuthLayoutProps) {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-screen-sm flex-col justify-center gap-6 p-6">
+      <header className="flex flex-col items-center gap-2 text-center">
+        <Link to="/" className="text-3xl font-bold text-emerald-600 dark:text-emerald-400">
+          🍆 가지마켓
+        </Link>
+        <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-50">{props.title}</h1>
+        <p className="text-sm text-gray-600 dark:text-gray-400">{props.description}</p>
+      </header>
+
+      <section className="flex flex-col gap-4 rounded-2xl border border-gray-200 bg-white p-6
+                          shadow-sm dark:border-gray-800 dark:bg-gray-950">
+        {props.children}
+      </section>
+
+      <footer className="text-center text-sm text-gray-600 dark:text-gray-400">
+        {props.footer}
+      </footer>
+    </main>
+  );
+}
+
+export default AuthLayout;

--- a/src/features/auth/components/authSessionProvider.tsx
+++ b/src/features/auth/components/authSessionProvider.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react';
+import { useAuthSessionSync } from '../hooks/useAuthSessionSync';
+
+type AuthSessionProviderProps = {
+  children: ReactNode;
+};
+
+/** Supabase 세션을 authStore에 동기화하는 구독을 앱 전역에 한 번만 건다. */
+function AuthSessionProvider(props: AuthSessionProviderProps) {
+  useAuthSessionSync();
+
+  return <>{props.children}</>;
+}
+
+export default AuthSessionProvider;

--- a/src/features/auth/components/authSubmitButton.tsx
+++ b/src/features/auth/components/authSubmitButton.tsx
@@ -1,0 +1,20 @@
+type AuthSubmitButtonProps = {
+  label: string;
+  pendingLabel: string;
+  isPending: boolean;
+};
+
+function AuthSubmitButton(props: AuthSubmitButtonProps) {
+  return (
+    <button
+      type="submit"
+      disabled={props.isPending}
+      className="w-full rounded-lg bg-emerald-600 px-4 py-2.5 text-sm font-semibold text-white
+                 transition hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-60"
+    >
+      {props.isPending ? props.pendingLabel : props.label}
+    </button>
+  );
+}
+
+export default AuthSubmitButton;

--- a/src/features/auth/components/authTextField.tsx
+++ b/src/features/auth/components/authTextField.tsx
@@ -1,0 +1,63 @@
+import type { ChangeEvent } from 'react';
+
+type AuthTextFieldProps = {
+  id: string;
+  label: string;
+  type: 'email' | 'password';
+  value: string;
+  autoComplete: string;
+  placeholder?: string;
+  errorMessage?: string;
+  disabled?: boolean;
+  onValueChange(value: string): void;
+};
+
+const BASE_INPUT_CLASS =
+  'w-full rounded-lg border px-3 py-2.5 text-sm outline-none transition ' +
+  'bg-white text-gray-900 placeholder:text-gray-400 ' +
+  'focus:ring-2 focus:ring-emerald-500/40 disabled:opacity-60 ' +
+  'dark:bg-gray-900 dark:text-gray-50 dark:placeholder:text-gray-500';
+
+function AuthTextField(props: AuthTextFieldProps) {
+  const errorId = `${props.id}-error`;
+  const hasError = props.errorMessage !== undefined;
+
+  function handleChange(event: ChangeEvent<HTMLInputElement>): void {
+    props.onValueChange(event.target.value);
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label
+        htmlFor={props.id}
+        className="text-sm font-medium text-gray-700 dark:text-gray-200"
+      >
+        {props.label}
+      </label>
+      <input
+        id={props.id}
+        name={props.id}
+        type={props.type}
+        value={props.value}
+        autoComplete={props.autoComplete}
+        placeholder={props.placeholder}
+        disabled={props.disabled === true}
+        aria-invalid={hasError}
+        aria-describedby={hasError ? errorId : undefined}
+        onChange={handleChange}
+        className={`${BASE_INPUT_CLASS} ${
+          hasError
+            ? 'border-red-500 focus:ring-red-500/40'
+            : 'border-gray-300 dark:border-gray-700'
+        }`}
+      />
+      {hasError ? (
+        <p id={errorId} role="alert" className="text-xs text-red-600 dark:text-red-400">
+          {props.errorMessage}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+export default AuthTextField;

--- a/src/features/auth/components/googleSignInButton.tsx
+++ b/src/features/auth/components/googleSignInButton.tsx
@@ -1,0 +1,47 @@
+type GoogleSignInButtonProps = {
+  label: string;
+  isPending: boolean;
+  onClick(): void;
+};
+
+function GoogleLogoIcon() {
+  return (
+    <svg viewBox="0 0 18 18" width="18" height="18" aria-hidden="true">
+      <path
+        fill="#4285F4"
+        d="M17.64 9.2c0-.64-.06-1.25-.16-1.84H9v3.48h4.84a4.14 4.14 0 0 1-1.8 2.72v2.26h2.92c1.7-1.57 2.68-3.88 2.68-6.62z"
+      />
+      <path
+        fill="#34A853"
+        d="M9 18c2.43 0 4.47-.8 5.96-2.18l-2.92-2.26c-.8.54-1.84.86-3.04.86-2.34 0-4.32-1.58-5.03-3.7H.96v2.33A9 9 0 0 0 9 18z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M3.97 10.72a5.4 5.4 0 0 1 0-3.44V4.95H.96a9 9 0 0 0 0 8.1l3.01-2.33z"
+      />
+      <path
+        fill="#EA4335"
+        d="M9 3.58c1.32 0 2.5.45 3.44 1.35l2.58-2.58C13.46.89 11.43 0 9 0A9 9 0 0 0 .96 4.95l3.01 2.33C4.68 5.16 6.66 3.58 9 3.58z"
+      />
+    </svg>
+  );
+}
+
+function GoogleSignInButton(props: GoogleSignInButtonProps) {
+  return (
+    <button
+      type="button"
+      disabled={props.isPending}
+      onClick={props.onClick}
+      className="flex w-full items-center justify-center gap-2 rounded-lg border border-gray-300
+                 bg-white px-4 py-2.5 text-sm font-semibold text-gray-700 transition
+                 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60
+                 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800"
+    >
+      <GoogleLogoIcon />
+      {props.isPending ? '구글로 이동 중…' : props.label}
+    </button>
+  );
+}
+
+export default GoogleSignInButton;

--- a/src/features/auth/components/logoutButton.tsx
+++ b/src/features/auth/components/logoutButton.tsx
@@ -1,0 +1,32 @@
+import { useSignOutMutation } from '../hooks/useAuthMutations';
+import { toAuthErrorMessage } from '../utils/authErrorMessage';
+
+function LogoutButton() {
+  const signOutMutation = useSignOutMutation();
+
+  function handleClick(): void {
+    signOutMutation.mutate();
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <button
+        type="button"
+        disabled={signOutMutation.isPending}
+        onClick={handleClick}
+        className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-700
+                   transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60
+                   dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800"
+      >
+        {signOutMutation.isPending ? '로그아웃 중…' : '로그아웃'}
+      </button>
+      {signOutMutation.error !== null ? (
+        <p role="alert" className="text-xs text-red-600 dark:text-red-400">
+          {toAuthErrorMessage(signOutMutation.error)}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+export default LogoutButton;

--- a/src/features/auth/components/signInForm.test.tsx
+++ b/src/features/auth/components/signInForm.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SignInForm from './signInForm';
+
+describe('SignInForm', function signInFormSuite() {
+  it('이메일 형식이 틀리면 오류를 보여주고 onSubmit을 호출하지 않는다', async function invalidEmailCase() {
+    const handleSubmit = jest.fn();
+    render(<SignInForm isPending={false} onSubmit={handleSubmit} />);
+
+    await userEvent.type(screen.getByLabelText('이메일'), 'eggplant.example.com');
+    await userEvent.type(screen.getByLabelText('비밀번호'), 'eggplant1234');
+    await userEvent.click(screen.getByRole('button', { name: '로그인' }));
+
+    expect(await screen.findByText('이메일 형식이 올바르지 않습니다.')).toBeInTheDocument();
+    expect(handleSubmit).not.toHaveBeenCalled();
+  });
+
+  it('올바른 입력이면 onSubmit을 호출한다', async function validSubmitCase() {
+    const handleSubmit = jest.fn();
+    render(<SignInForm isPending={false} onSubmit={handleSubmit} />);
+
+    await userEvent.type(screen.getByLabelText('이메일'), 'eggplant@example.com');
+    await userEvent.type(screen.getByLabelText('비밀번호'), 'eggplant1234');
+    await userEvent.click(screen.getByRole('button', { name: '로그인' }));
+
+    expect(handleSubmit).toHaveBeenCalledWith({
+      email: 'eggplant@example.com',
+      password: 'eggplant1234',
+    });
+  });
+
+  it('처리 중에는 버튼이 잠긴다', function pendingCase() {
+    render(<SignInForm isPending onSubmit={jest.fn()} />);
+
+    expect(screen.getByRole('button', { name: '로그인 중…' })).toBeDisabled();
+  });
+});

--- a/src/features/auth/components/signInForm.tsx
+++ b/src/features/auth/components/signInForm.tsx
@@ -1,0 +1,71 @@
+import { useState, type FormEvent } from 'react';
+import AuthSubmitButton from './authSubmitButton';
+import AuthTextField from './authTextField';
+import type { AuthFieldErrors, EmailCredentials } from '../types';
+import { hasAuthFieldError, validateSignInValues } from '../utils/validateAuthInput';
+
+type SignInFormProps = {
+  isPending: boolean;
+  onSubmit(credentials: EmailCredentials): void;
+};
+
+const EMPTY_SIGN_IN_VALUES: EmailCredentials = {
+  email: '',
+  password: '',
+};
+
+function SignInForm(props: SignInFormProps) {
+  const [values, setValues] = useState<EmailCredentials>(EMPTY_SIGN_IN_VALUES);
+  const [errors, setErrors] = useState<AuthFieldErrors>({});
+
+  function updateField(field: keyof EmailCredentials, value: string): void {
+    setValues(function mergeField(previous) {
+      return { ...previous, [field]: value };
+    });
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault();
+
+    const nextErrors = validateSignInValues(values);
+    setErrors(nextErrors);
+    if (hasAuthFieldError(nextErrors)) {
+      return;
+    }
+
+    props.onSubmit({ email: values.email.trim(), password: values.password });
+  }
+
+  return (
+    <form noValidate onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <AuthTextField
+        id="email"
+        label="이메일"
+        type="email"
+        value={values.email}
+        autoComplete="email"
+        placeholder="eggplant@example.com"
+        errorMessage={errors.email}
+        disabled={props.isPending}
+        onValueChange={function handleEmailChange(value) {
+          updateField('email', value);
+        }}
+      />
+      <AuthTextField
+        id="password"
+        label="비밀번호"
+        type="password"
+        value={values.password}
+        autoComplete="current-password"
+        errorMessage={errors.password}
+        disabled={props.isPending}
+        onValueChange={function handlePasswordChange(value) {
+          updateField('password', value);
+        }}
+      />
+      <AuthSubmitButton label="로그인" pendingLabel="로그인 중…" isPending={props.isPending} />
+    </form>
+  );
+}
+
+export default SignInForm;

--- a/src/features/auth/components/signInPage.tsx
+++ b/src/features/auth/components/signInPage.tsx
@@ -1,0 +1,72 @@
+import { Link, Navigate, useNavigate } from 'react-router-dom';
+import AuthDivider from './authDivider';
+import AuthFormMessage from './authFormMessage';
+import AuthLayout from './authLayout';
+import GoogleSignInButton from './googleSignInButton';
+import SignInForm from './signInForm';
+import {
+  useEmailSignInMutation,
+  useGoogleSignInMutation,
+} from '../hooks/useAuthMutations';
+import { selectAuthStatus, useAuthStore } from '../store/authStore';
+import type { EmailCredentials } from '../types';
+import { toAuthErrorMessage } from '../utils/authErrorMessage';
+
+function SignInPage() {
+  const navigate = useNavigate();
+  const status = useAuthStore(selectAuthStatus);
+  const signInMutation = useEmailSignInMutation();
+  const googleSignInMutation = useGoogleSignInMutation();
+
+  function handleSubmit(credentials: EmailCredentials): void {
+    signInMutation.mutate(credentials, {
+      onSuccess: function handleSignedIn(): void {
+        navigate('/', { replace: true });
+      },
+    });
+  }
+
+  function handleGoogleClick(): void {
+    googleSignInMutation.mutate();
+  }
+
+  if (status === 'authenticated') {
+    return <Navigate to="/" replace />;
+  }
+
+  const errorMessage =
+    signInMutation.error !== null
+      ? toAuthErrorMessage(signInMutation.error)
+      : googleSignInMutation.error !== null
+        ? toAuthErrorMessage(googleSignInMutation.error)
+        : null;
+
+  return (
+    <AuthLayout
+      title="로그인"
+      description="가지마켓에 오신 것을 환영합니다."
+      footer={
+        <span>
+          아직 계정이 없으신가요?{' '}
+          <Link to="/signup" className="font-semibold text-emerald-600 dark:text-emerald-400">
+            회원가입
+          </Link>
+        </span>
+      }
+    >
+      {errorMessage !== null ? <AuthFormMessage tone="error" message={errorMessage} /> : null}
+
+      <SignInForm isPending={signInMutation.isPending} onSubmit={handleSubmit} />
+
+      <AuthDivider />
+
+      <GoogleSignInButton
+        label="구글로 로그인"
+        isPending={googleSignInMutation.isPending}
+        onClick={handleGoogleClick}
+      />
+    </AuthLayout>
+  );
+}
+
+export default SignInPage;

--- a/src/features/auth/components/signUpForm.test.tsx
+++ b/src/features/auth/components/signUpForm.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SignUpForm from './signUpForm';
+
+describe('SignUpForm', function signUpFormSuite() {
+  it('빈 값으로 제출하면 필드 오류를 보여주고 onSubmit을 호출하지 않는다', async function emptySubmitCase() {
+    const handleSubmit = jest.fn();
+    render(<SignUpForm isPending={false} onSubmit={handleSubmit} />);
+
+    await userEvent.click(screen.getByRole('button', { name: '회원가입' }));
+
+    expect(await screen.findByText('이메일을 입력해 주세요.')).toBeInTheDocument();
+    expect(screen.getByText('비밀번호를 입력해 주세요.')).toBeInTheDocument();
+    expect(handleSubmit).not.toHaveBeenCalled();
+  });
+
+  it('비밀번호 확인이 다르면 불일치 오류를 보여준다', async function mismatchCase() {
+    const handleSubmit = jest.fn();
+    render(<SignUpForm isPending={false} onSubmit={handleSubmit} />);
+
+    await userEvent.type(screen.getByLabelText('이메일'), 'eggplant@example.com');
+    await userEvent.type(screen.getByLabelText('비밀번호'), 'eggplant1234');
+    await userEvent.type(screen.getByLabelText('비밀번호 확인'), 'eggplant4321');
+    await userEvent.click(screen.getByRole('button', { name: '회원가입' }));
+
+    expect(await screen.findByText('비밀번호가 일치하지 않습니다.')).toBeInTheDocument();
+    expect(handleSubmit).not.toHaveBeenCalled();
+  });
+
+  it('올바른 입력이면 공백을 제거한 자격증명으로 onSubmit을 호출한다', async function validSubmitCase() {
+    const handleSubmit = jest.fn();
+    render(<SignUpForm isPending={false} onSubmit={handleSubmit} />);
+
+    await userEvent.type(screen.getByLabelText('이메일'), '  eggplant@example.com  ');
+    await userEvent.type(screen.getByLabelText('비밀번호'), 'eggplant1234');
+    await userEvent.type(screen.getByLabelText('비밀번호 확인'), 'eggplant1234');
+    await userEvent.click(screen.getByRole('button', { name: '회원가입' }));
+
+    expect(handleSubmit).toHaveBeenCalledTimes(1);
+    expect(handleSubmit).toHaveBeenCalledWith({
+      email: 'eggplant@example.com',
+      password: 'eggplant1234',
+    });
+  });
+
+  it('처리 중에는 버튼과 입력을 잠근다', function pendingCase() {
+    render(<SignUpForm isPending onSubmit={jest.fn()} />);
+
+    expect(screen.getByRole('button', { name: '가입 중…' })).toBeDisabled();
+    expect(screen.getByLabelText('이메일')).toBeDisabled();
+  });
+});

--- a/src/features/auth/components/signUpForm.tsx
+++ b/src/features/auth/components/signUpForm.tsx
@@ -1,0 +1,85 @@
+import { useState, type FormEvent } from 'react';
+import AuthSubmitButton from './authSubmitButton';
+import AuthTextField from './authTextField';
+import type { AuthFieldErrors, EmailCredentials, SignUpValues } from '../types';
+import { hasAuthFieldError, validateSignUpValues } from '../utils/validateAuthInput';
+
+type SignUpFormProps = {
+  isPending: boolean;
+  onSubmit(credentials: EmailCredentials): void;
+};
+
+const EMPTY_SIGN_UP_VALUES: SignUpValues = {
+  email: '',
+  password: '',
+  passwordConfirm: '',
+};
+
+function SignUpForm(props: SignUpFormProps) {
+  const [values, setValues] = useState<SignUpValues>(EMPTY_SIGN_UP_VALUES);
+  const [errors, setErrors] = useState<AuthFieldErrors>({});
+
+  function updateField(field: keyof SignUpValues, value: string): void {
+    setValues(function mergeField(previous) {
+      return { ...previous, [field]: value };
+    });
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault();
+
+    const nextErrors = validateSignUpValues(values);
+    setErrors(nextErrors);
+    if (hasAuthFieldError(nextErrors)) {
+      return;
+    }
+
+    props.onSubmit({ email: values.email.trim(), password: values.password });
+  }
+
+  return (
+    <form noValidate onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <AuthTextField
+        id="email"
+        label="이메일"
+        type="email"
+        value={values.email}
+        autoComplete="email"
+        placeholder="eggplant@example.com"
+        errorMessage={errors.email}
+        disabled={props.isPending}
+        onValueChange={function handleEmailChange(value) {
+          updateField('email', value);
+        }}
+      />
+      <AuthTextField
+        id="password"
+        label="비밀번호"
+        type="password"
+        value={values.password}
+        autoComplete="new-password"
+        placeholder="8자 이상"
+        errorMessage={errors.password}
+        disabled={props.isPending}
+        onValueChange={function handlePasswordChange(value) {
+          updateField('password', value);
+        }}
+      />
+      <AuthTextField
+        id="passwordConfirm"
+        label="비밀번호 확인"
+        type="password"
+        value={values.passwordConfirm}
+        autoComplete="new-password"
+        errorMessage={errors.passwordConfirm}
+        disabled={props.isPending}
+        onValueChange={function handlePasswordConfirmChange(value) {
+          updateField('passwordConfirm', value);
+        }}
+      />
+      <AuthSubmitButton label="회원가입" pendingLabel="가입 중…" isPending={props.isPending} />
+    </form>
+  );
+}
+
+export default SignUpForm;

--- a/src/features/auth/components/signUpPage.tsx
+++ b/src/features/auth/components/signUpPage.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+import { Link, Navigate, useNavigate } from 'react-router-dom';
+import AuthDivider from './authDivider';
+import AuthFormMessage from './authFormMessage';
+import AuthLayout from './authLayout';
+import GoogleSignInButton from './googleSignInButton';
+import SignUpForm from './signUpForm';
+import {
+  useEmailSignUpMutation,
+  useGoogleSignInMutation,
+} from '../hooks/useAuthMutations';
+import { selectAuthStatus, useAuthStore } from '../store/authStore';
+import type { EmailCredentials, SignUpResult } from '../types';
+import { toAuthErrorMessage } from '../utils/authErrorMessage';
+
+const EMAIL_CONFIRM_NOTICE =
+  '인증 메일을 보냈습니다. 메일의 링크를 눌러 가입을 완료해 주세요.';
+
+function SignUpPage() {
+  const navigate = useNavigate();
+  const status = useAuthStore(selectAuthStatus);
+  const signUpMutation = useEmailSignUpMutation();
+  const googleSignInMutation = useGoogleSignInMutation();
+  const [noticeMessage, setNoticeMessage] = useState<string | null>(null);
+
+  function handleSignUpSuccess(result: SignUpResult): void {
+    if (result.needsEmailConfirm) {
+      setNoticeMessage(EMAIL_CONFIRM_NOTICE);
+      return;
+    }
+    navigate('/', { replace: true });
+  }
+
+  function handleSubmit(credentials: EmailCredentials): void {
+    setNoticeMessage(null);
+    signUpMutation.mutate(credentials, { onSuccess: handleSignUpSuccess });
+  }
+
+  function handleGoogleClick(): void {
+    setNoticeMessage(null);
+    googleSignInMutation.mutate();
+  }
+
+  if (status === 'authenticated') {
+    return <Navigate to="/" replace />;
+  }
+
+  const errorMessage =
+    signUpMutation.error !== null
+      ? toAuthErrorMessage(signUpMutation.error)
+      : googleSignInMutation.error !== null
+        ? toAuthErrorMessage(googleSignInMutation.error)
+        : null;
+
+  return (
+    <AuthLayout
+      title="회원가입"
+      description="이웃과 중고거래를 시작해 보세요."
+      footer={
+        <span>
+          이미 계정이 있으신가요?{' '}
+          <Link to="/login" className="font-semibold text-emerald-600 dark:text-emerald-400">
+            로그인
+          </Link>
+        </span>
+      }
+    >
+      {errorMessage !== null ? <AuthFormMessage tone="error" message={errorMessage} /> : null}
+      {noticeMessage !== null ? <AuthFormMessage tone="info" message={noticeMessage} /> : null}
+
+      <SignUpForm isPending={signUpMutation.isPending} onSubmit={handleSubmit} />
+
+      <AuthDivider />
+
+      <GoogleSignInButton
+        label="구글로 시작하기"
+        isPending={googleSignInMutation.isPending}
+        onClick={handleGoogleClick}
+      />
+    </AuthLayout>
+  );
+}
+
+export default SignUpPage;

--- a/src/features/auth/hooks/useAuthMutations.ts
+++ b/src/features/auth/hooks/useAuthMutations.ts
@@ -1,0 +1,49 @@
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+import {
+  signInWithEmail,
+  signInWithGoogle,
+  signOut,
+  signUpWithEmail,
+} from '../api/authApi';
+import { selectClearSession, useAuthStore } from '../store/authStore';
+import type { AuthSession, EmailCredentials, SignUpResult } from '../types';
+
+export function useEmailSignUpMutation(): UseMutationResult<
+  SignUpResult,
+  Error,
+  EmailCredentials
+> {
+  return useMutation<SignUpResult, Error, EmailCredentials>({
+    mutationFn: signUpWithEmail,
+  });
+}
+
+export function useEmailSignInMutation(): UseMutationResult<
+  AuthSession,
+  Error,
+  EmailCredentials
+> {
+  return useMutation<AuthSession, Error, EmailCredentials>({
+    mutationFn: signInWithEmail,
+  });
+}
+
+export function useGoogleSignInMutation(): UseMutationResult<void, Error, void> {
+  return useMutation<void, Error, void>({
+    mutationFn: signInWithGoogle,
+  });
+}
+
+/** 로그아웃 시 이전 사용자의 서버 데이터가 남지 않도록 쿼리 캐시도 비운다. */
+export function useSignOutMutation(): UseMutationResult<void, Error, void> {
+  const queryClient = useQueryClient();
+  const clearSession = useAuthStore(selectClearSession);
+
+  return useMutation<void, Error, void>({
+    mutationFn: signOut,
+    onSuccess: function handleSignedOut(): void {
+      clearSession();
+      queryClient.clear();
+    },
+  });
+}

--- a/src/features/auth/hooks/useAuthSessionSync.ts
+++ b/src/features/auth/hooks/useAuthSessionSync.ts
@@ -1,0 +1,44 @@
+import { useEffect } from 'react';
+import { getCurrentSession, subscribeToAuthChanges } from '../api/authApi';
+import { selectSetSession, useAuthStore } from '../store/authStore';
+
+/**
+ * 앱 시작 시 저장된 세션을 한 번 읽고, 이후 Supabase 인증 이벤트를 authStore에 동기화한다.
+ * (로그인/로그아웃/토큰 갱신/OAuth 복귀 모두 이 구독으로 처리)
+ */
+export function useAuthSessionSync(): void {
+  const setSession = useAuthStore(selectSetSession);
+
+  useEffect(
+    function syncAuthSession() {
+      let isActive = true;
+
+      async function loadInitialSession(): Promise<void> {
+        const session = await getCurrentSession();
+        if (isActive) {
+          setSession(session);
+        }
+      }
+
+      loadInitialSession().catch(function handleInitialSessionError() {
+        // 세션 조회 실패는 비로그인으로 간주한다(로딩 상태에 갇히지 않도록).
+        if (isActive) {
+          setSession(null);
+        }
+      });
+
+      const unsubscribe = subscribeToAuthChanges(function handleAuthChange(
+        _event,
+        session,
+      ) {
+        setSession(session);
+      });
+
+      return function cleanupAuthSync(): void {
+        isActive = false;
+        unsubscribe();
+      };
+    },
+    [setSession],
+  );
+}

--- a/src/features/auth/store/authStore.test.ts
+++ b/src/features/auth/store/authStore.test.ts
@@ -1,0 +1,63 @@
+import { AUTH_INITIAL_STATE, useAuthStore } from './authStore';
+import type { AuthSession } from '../types';
+
+// Supabase가 돌려주는 세션 객체의 최소 형태(테스트 픽스처).
+function createSession(userId: string, email: string): AuthSession {
+  return {
+    access_token: `access-${userId}`,
+    refresh_token: `refresh-${userId}`,
+    expires_in: 3600,
+    token_type: 'bearer',
+    user: {
+      id: userId,
+      email,
+      aud: 'authenticated',
+      role: 'authenticated',
+      app_metadata: { provider: 'email' },
+      user_metadata: {},
+      created_at: '2026-08-01T00:00:00.000Z',
+    },
+  };
+}
+
+describe('authStore', function authStoreSuite() {
+  beforeEach(function resetStore() {
+    useAuthStore.setState(AUTH_INITIAL_STATE);
+  });
+
+  it('초기 상태는 loading이며 세션이 없다', function initialCase() {
+    const state = useAuthStore.getState();
+    expect(state.status).toBe('loading');
+    expect(state.session).toBeNull();
+    expect(state.user).toBeNull();
+  });
+
+  it('세션을 넣으면 authenticated가 되고 user를 꺼내 둔다', function setSessionCase() {
+    const session = createSession('user-1', 'eggplant@example.com');
+
+    useAuthStore.getState().setSession(session);
+
+    const state = useAuthStore.getState();
+    expect(state.status).toBe('authenticated');
+    expect(state.session).toBe(session);
+    expect(state.user?.email).toBe('eggplant@example.com');
+  });
+
+  it('null 세션을 넣으면 unauthenticated가 된다 (loading과 구분)', function setNullSessionCase() {
+    useAuthStore.getState().setSession(null);
+
+    const state = useAuthStore.getState();
+    expect(state.status).toBe('unauthenticated');
+    expect(state.user).toBeNull();
+  });
+
+  it('clearSession은 로그인 상태를 비운다', function clearSessionCase() {
+    useAuthStore.getState().setSession(createSession('user-2', 'neighbor@example.com'));
+    useAuthStore.getState().clearSession();
+
+    const state = useAuthStore.getState();
+    expect(state.status).toBe('unauthenticated');
+    expect(state.session).toBeNull();
+    expect(state.user).toBeNull();
+  });
+});

--- a/src/features/auth/store/authStore.ts
+++ b/src/features/auth/store/authStore.ts
@@ -1,0 +1,53 @@
+import { create } from 'zustand';
+import type { AuthSession, AuthStatus, AuthUser } from '../types';
+
+type AuthStoreState = {
+  session: AuthSession | null;
+  user: AuthUser | null;
+  status: AuthStatus;
+  setSession(session: AuthSession | null): void;
+  clearSession(): void;
+};
+
+type AuthSnapshot = Pick<AuthStoreState, 'session' | 'user' | 'status'>;
+
+export const AUTH_INITIAL_STATE: AuthSnapshot = {
+  session: null,
+  user: null,
+  status: 'loading',
+};
+
+function toSnapshot(session: AuthSession | null): AuthSnapshot {
+  if (session === null) {
+    return { session: null, user: null, status: 'unauthenticated' };
+  }
+  return { session, user: session.user, status: 'authenticated' };
+}
+
+export const useAuthStore = create<AuthStoreState>(function initAuthStore(set) {
+  return {
+    ...AUTH_INITIAL_STATE,
+    setSession(session) {
+      set(toSnapshot(session));
+    },
+    clearSession() {
+      set(toSnapshot(null));
+    },
+  };
+});
+
+export function selectAuthStatus(state: AuthStoreState): AuthStatus {
+  return state.status;
+}
+
+export function selectAuthUser(state: AuthStoreState): AuthUser | null {
+  return state.user;
+}
+
+export function selectSetSession(state: AuthStoreState): AuthStoreState['setSession'] {
+  return state.setSession;
+}
+
+export function selectClearSession(state: AuthStoreState): AuthStoreState['clearSession'] {
+  return state.clearSession;
+}

--- a/src/features/auth/types.ts
+++ b/src/features/auth/types.ts
@@ -1,0 +1,26 @@
+import type { Session, User } from '@supabase/supabase-js';
+
+export type AuthSession = Session;
+export type AuthUser = User;
+
+/** 세션 확인 전에는 'loading'. 화면 깜빡임(로그인 화면 잠깐 노출)을 막기 위해 구분한다. */
+export type AuthStatus = 'loading' | 'authenticated' | 'unauthenticated';
+
+export type EmailCredentials = {
+  email: string;
+  password: string;
+};
+
+export type SignUpValues = EmailCredentials & {
+  passwordConfirm: string;
+};
+
+export type AuthFieldName = 'email' | 'password' | 'passwordConfirm';
+
+export type AuthFieldErrors = Partial<Record<AuthFieldName, string>>;
+
+export type SignUpResult = {
+  session: AuthSession | null;
+  /** Supabase에서 이메일 확인이 켜져 있으면 세션 없이 가입만 완료된다. */
+  needsEmailConfirm: boolean;
+};

--- a/src/features/auth/utils/authErrorMessage.test.ts
+++ b/src/features/auth/utils/authErrorMessage.test.ts
@@ -1,0 +1,75 @@
+import { toAuthErrorMessage } from './authErrorMessage';
+
+const DEFAULT_MESSAGE = '요청을 처리하지 못했습니다. 잠시 후 다시 시도해 주세요.';
+
+describe('toAuthErrorMessage', function toAuthErrorMessageSuite() {
+  it('로그인 실패를 한국어로 바꾼다', function invalidCredentialsCase() {
+    expect(toAuthErrorMessage(new Error('Invalid login credentials'))).toBe(
+      '이메일 또는 비밀번호가 올바르지 않습니다.',
+    );
+  });
+
+  it('중복 가입을 한국어로 바꾼다', function alreadyRegisteredCase() {
+    expect(toAuthErrorMessage(new Error('User already registered'))).toBe(
+      '이미 가입된 이메일입니다.',
+    );
+  });
+
+  it('message 없이 code만 있어도 매칭한다', function codeOnlyCase() {
+    expect(toAuthErrorMessage({ code: 'email_not_confirmed' })).toBe(
+      '이메일 인증이 완료되지 않았습니다. 받은 편지함을 확인해 주세요.',
+    );
+  });
+
+  it('네트워크 오류를 한국어로 바꾼다', function networkCase() {
+    expect(toAuthErrorMessage(new TypeError('Failed to fetch'))).toBe(
+      '네트워크 연결을 확인해 주세요.',
+    );
+  });
+
+  // 아래 4건은 실제 Supabase 프로젝트에서 관측한 응답 그대로다.
+  it('구글 미활성화는 validation_failed보다 provider 문구를 우선한다', function providerDisabledCase() {
+    expect(
+      toAuthErrorMessage({
+        code: 'validation_failed',
+        message: 'Unsupported provider: provider is not enabled',
+      }),
+    ).toBe('해당 소셜 로그인이 아직 활성화되지 않았습니다.');
+  });
+
+  it('사용할 수 없는 이메일 도메인을 안내한다', function invalidEmailDomainCase() {
+    expect(
+      toAuthErrorMessage({
+        code: 'email_address_invalid',
+        message: 'Email address "verify@example.com" is invalid',
+      }),
+    ).toBe('사용할 수 없는 이메일 주소입니다. 다른 이메일로 시도해 주세요.');
+  });
+
+  it('메일 발송 rate limit을 안내한다', function emailRateLimitCase() {
+    expect(
+      toAuthErrorMessage({
+        code: 'over_email_send_rate_limit',
+        message: 'email rate limit exceeded',
+      }),
+    ).toBe('요청이 너무 잦습니다. 잠시 후 다시 시도해 주세요.');
+  });
+
+  it('만료된 세션은 재로그인을 안내한다', function expiredSessionCase() {
+    expect(
+      toAuthErrorMessage({
+        code: 'refresh_token_not_found',
+        message: 'Invalid Refresh Token: Refresh Token Not Found',
+      }),
+    ).toBe('로그인이 만료되었습니다. 다시 로그인해 주세요.');
+  });
+
+  it('알 수 없는 오류는 기본 문구를 반환한다', function unknownCase() {
+    expect(toAuthErrorMessage(new Error('something exploded'))).toBe(DEFAULT_MESSAGE);
+  });
+
+  it('null·undefined도 기본 문구를 반환한다', function nullishCase() {
+    expect(toAuthErrorMessage(null)).toBe(DEFAULT_MESSAGE);
+    expect(toAuthErrorMessage(undefined)).toBe(DEFAULT_MESSAGE);
+  });
+});

--- a/src/features/auth/utils/authErrorMessage.ts
+++ b/src/features/auth/utils/authErrorMessage.ts
@@ -1,0 +1,59 @@
+// Supabase Auth 오류(영문 message/code)를 사용자에게 보여줄 한국어 문구로 바꾼다.
+
+const DEFAULT_AUTH_ERROR_MESSAGE = '요청을 처리하지 못했습니다. 잠시 후 다시 시도해 주세요.';
+
+// 순서가 곧 우선순위다. 구체적인 원인을 위에 둔다.
+// (예: 구글 미활성화 응답은 code=validation_failed + msg="provider is not enabled"이므로
+//  provider 패턴이 validation_failed보다 먼저 와야 한다.)
+const MESSAGE_BY_PATTERN: ReadonlyArray<readonly [RegExp, string]> = [
+  [/invalid_credentials|invalid login credentials/, '이메일 또는 비밀번호가 올바르지 않습니다.'],
+  [/user_already_exists|already registered|already been registered/, '이미 가입된 이메일입니다.'],
+  [/email_not_confirmed|email not confirmed/, '이메일 인증이 완료되지 않았습니다. 받은 편지함을 확인해 주세요.'],
+  [/weak_password|password should be at least/, '비밀번호가 너무 단순합니다. 더 복잡하게 설정해 주세요.'],
+  [/email_address_invalid|email address .* is invalid/, '사용할 수 없는 이메일 주소입니다. 다른 이메일로 시도해 주세요.'],
+  [/rate limit|too many requests/, '요청이 너무 잦습니다. 잠시 후 다시 시도해 주세요.'],
+  [/provider is not enabled|unsupported provider|oauth/, '해당 소셜 로그인이 아직 활성화되지 않았습니다.'],
+  [/refresh_token_not_found|bad_jwt|session_not_found/, '로그인이 만료되었습니다. 다시 로그인해 주세요.'],
+  [/validation_failed|invalid email/, '입력값을 다시 확인해 주세요.'],
+  [/failed to fetch|network|networkerror/, '네트워크 연결을 확인해 주세요.'],
+];
+
+type ErrorLike = {
+  message?: unknown;
+  code?: unknown;
+};
+
+/** Error 인스턴스가 아닐 수도 있으므로(직렬화된 응답 등) code·message를 모아 문자열로 만든다. */
+function extractErrorText(error: unknown): string {
+  if (typeof error === 'string') {
+    return error;
+  }
+  if (error === null || typeof error !== 'object') {
+    return '';
+  }
+
+  const candidate = error as ErrorLike;
+  const parts: string[] = [];
+  if (typeof candidate.code === 'string') {
+    parts.push(candidate.code);
+  }
+  if (typeof candidate.message === 'string') {
+    parts.push(candidate.message);
+  }
+  return parts.join(' ');
+}
+
+export function toAuthErrorMessage(error: unknown): string {
+  const text = extractErrorText(error).toLowerCase();
+  if (text.length === 0) {
+    return DEFAULT_AUTH_ERROR_MESSAGE;
+  }
+
+  for (const [pattern, message] of MESSAGE_BY_PATTERN) {
+    if (pattern.test(text)) {
+      return message;
+    }
+  }
+
+  return DEFAULT_AUTH_ERROR_MESSAGE;
+}

--- a/src/features/auth/utils/validateAuthInput.test.ts
+++ b/src/features/auth/utils/validateAuthInput.test.ts
@@ -1,0 +1,97 @@
+import {
+  hasAuthFieldError,
+  validateEmail,
+  validatePassword,
+  validatePasswordConfirm,
+  validateSignInValues,
+  validateSignUpValues,
+} from './validateAuthInput';
+
+describe('validateEmail', function validateEmailSuite() {
+  it('빈 값이면 입력 안내를 반환한다', function emptyCase() {
+    expect(validateEmail('   ')).toBe('이메일을 입력해 주세요.');
+  });
+
+  it('형식이 틀리면 오류를 반환한다', function invalidCase() {
+    expect(validateEmail('eggplant.example.com')).toBe('이메일 형식이 올바르지 않습니다.');
+    expect(validateEmail('eggplant@example')).toBe('이메일 형식이 올바르지 않습니다.');
+  });
+
+  it('앞뒤 공백은 무시하고 통과시킨다', function validCase() {
+    expect(validateEmail('  eggplant@example.com  ')).toBeUndefined();
+  });
+});
+
+describe('validatePassword', function validatePasswordSuite() {
+  it('빈 값이면 입력 안내를 반환한다', function emptyCase() {
+    expect(validatePassword('')).toBe('비밀번호를 입력해 주세요.');
+  });
+
+  it('8자 미만이면 오류를 반환한다', function tooShortCase() {
+    expect(validatePassword('1234567')).toBe('비밀번호는 8자 이상이어야 합니다.');
+  });
+
+  it('72자를 넘으면 오류를 반환한다', function tooLongCase() {
+    expect(validatePassword('a'.repeat(73))).toBe('비밀번호는 72자 이하여야 합니다.');
+  });
+
+  it('8자 이상 72자 이하면 통과한다', function validCase() {
+    expect(validatePassword('eggplant1234')).toBeUndefined();
+    expect(validatePassword('a'.repeat(72))).toBeUndefined();
+  });
+});
+
+describe('validatePasswordConfirm', function validatePasswordConfirmSuite() {
+  it('확인값이 비어 있으면 입력 안내를 반환한다', function emptyCase() {
+    expect(validatePasswordConfirm('eggplant1234', '')).toBe('비밀번호를 한 번 더 입력해 주세요.');
+  });
+
+  it('두 값이 다르면 불일치 오류를 반환한다', function mismatchCase() {
+    expect(validatePasswordConfirm('eggplant1234', 'eggplant4321')).toBe(
+      '비밀번호가 일치하지 않습니다.',
+    );
+  });
+
+  it('두 값이 같으면 통과한다', function matchCase() {
+    expect(validatePasswordConfirm('eggplant1234', 'eggplant1234')).toBeUndefined();
+  });
+});
+
+describe('validateSignInValues', function validateSignInValuesSuite() {
+  it('올바른 입력이면 오류가 없다', function validCase() {
+    const errors = validateSignInValues({
+      email: 'eggplant@example.com',
+      password: 'eggplant1234',
+    });
+    expect(hasAuthFieldError(errors)).toBe(false);
+  });
+
+  it('두 필드가 모두 잘못되면 각각 오류를 담는다', function invalidCase() {
+    const errors = validateSignInValues({ email: 'nope', password: '123' });
+    expect(errors.email).toBeDefined();
+    expect(errors.password).toBeDefined();
+    expect(hasAuthFieldError(errors)).toBe(true);
+  });
+});
+
+describe('validateSignUpValues', function validateSignUpValuesSuite() {
+  it('세 필드가 모두 올바르면 오류가 없다', function validCase() {
+    const errors = validateSignUpValues({
+      email: 'eggplant@example.com',
+      password: 'eggplant1234',
+      passwordConfirm: 'eggplant1234',
+    });
+    expect(hasAuthFieldError(errors)).toBe(false);
+  });
+
+  it('비밀번호 확인이 다르면 passwordConfirm 오류만 발생한다', function mismatchCase() {
+    const errors = validateSignUpValues({
+      email: 'eggplant@example.com',
+      password: 'eggplant1234',
+      passwordConfirm: 'eggplant4321',
+    });
+    expect(errors.email).toBeUndefined();
+    expect(errors.password).toBeUndefined();
+    expect(errors.passwordConfirm).toBe('비밀번호가 일치하지 않습니다.');
+  });
+});

--- a/src/features/auth/utils/validateAuthInput.ts
+++ b/src/features/auth/utils/validateAuthInput.ts
@@ -1,0 +1,76 @@
+import type { AuthFieldErrors, EmailCredentials, SignUpValues } from '../types';
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MIN_PASSWORD_LENGTH = 8;
+const MAX_PASSWORD_LENGTH = 72; // Supabase(bcrypt) 상한
+
+export function validateEmail(email: string): string | undefined {
+  const trimmed = email.trim();
+  if (trimmed.length === 0) {
+    return '이메일을 입력해 주세요.';
+  }
+  if (!EMAIL_PATTERN.test(trimmed)) {
+    return '이메일 형식이 올바르지 않습니다.';
+  }
+  return undefined;
+}
+
+export function validatePassword(password: string): string | undefined {
+  if (password.length === 0) {
+    return '비밀번호를 입력해 주세요.';
+  }
+  if (password.length < MIN_PASSWORD_LENGTH) {
+    return `비밀번호는 ${MIN_PASSWORD_LENGTH}자 이상이어야 합니다.`;
+  }
+  if (password.length > MAX_PASSWORD_LENGTH) {
+    return `비밀번호는 ${MAX_PASSWORD_LENGTH}자 이하여야 합니다.`;
+  }
+  return undefined;
+}
+
+export function validatePasswordConfirm(
+  password: string,
+  passwordConfirm: string,
+): string | undefined {
+  if (passwordConfirm.length === 0) {
+    return '비밀번호를 한 번 더 입력해 주세요.';
+  }
+  if (password !== passwordConfirm) {
+    return '비밀번호가 일치하지 않습니다.';
+  }
+  return undefined;
+}
+
+export function validateSignInValues(values: EmailCredentials): AuthFieldErrors {
+  const errors: AuthFieldErrors = {};
+
+  const emailError = validateEmail(values.email);
+  if (emailError !== undefined) {
+    errors.email = emailError;
+  }
+
+  const passwordError = validatePassword(values.password);
+  if (passwordError !== undefined) {
+    errors.password = passwordError;
+  }
+
+  return errors;
+}
+
+export function validateSignUpValues(values: SignUpValues): AuthFieldErrors {
+  const errors = validateSignInValues(values);
+
+  const passwordConfirmError = validatePasswordConfirm(
+    values.password,
+    values.passwordConfirm,
+  );
+  if (passwordConfirmError !== undefined) {
+    errors.passwordConfirm = passwordConfirmError;
+  }
+
+  return errors;
+}
+
+export function hasAuthFieldError(errors: AuthFieldErrors): boolean {
+  return Object.keys(errors).length > 0;
+}

--- a/src/features/browse/components/homePage.tsx
+++ b/src/features/browse/components/homePage.tsx
@@ -1,12 +1,52 @@
+import { Link } from 'react-router-dom';
+import LogoutButton from '../../auth/components/logoutButton';
+import { selectAuthStatus, selectAuthUser, useAuthStore } from '../../auth/store/authStore';
+
+function GuestActions() {
+  return (
+    <div className="flex gap-2">
+      <Link
+        to="/login"
+        className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-emerald-700"
+      >
+        로그인
+      </Link>
+      <Link
+        to="/signup"
+        className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-700
+                   transition hover:bg-gray-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800"
+      >
+        회원가입
+      </Link>
+    </div>
+  );
+}
+
 function HomePage() {
+  const status = useAuthStore(selectAuthStatus);
+  const user = useAuthStore(selectAuthUser);
+
   return (
     <main className="mx-auto flex min-h-screen max-w-screen-sm flex-col items-center justify-center gap-3 p-6">
-      <h1 className="text-3xl font-bold text-emerald-600 dark:text-emerald-400">
-        🍆 가지마켓
-      </h1>
-      <p className="text-gray-600 dark:text-gray-300">
-        중고거래 플랫폼 기본 구조가 준비되었습니다.
-      </p>
+      <h1 className="text-3xl font-bold text-emerald-600 dark:text-emerald-400">🍆 가지마켓</h1>
+
+      {status === 'loading' ? (
+        <p className="text-gray-600 dark:text-gray-300">세션을 확인하는 중입니다…</p>
+      ) : status === 'authenticated' ? (
+        <>
+          <p className="text-gray-600 dark:text-gray-300">
+            <span className="font-semibold">{user?.email ?? '이웃'}</span>님, 반갑습니다.
+          </p>
+          <LogoutButton />
+        </>
+      ) : (
+        <>
+          <p className="text-gray-600 dark:text-gray-300">
+            로그인하고 우리 동네 중고거래를 시작해 보세요.
+          </p>
+          <GuestActions />
+        </>
+      )}
     </main>
   );
 }

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,13 @@
+1.회원가입
+
+2.로그인
+
+3.로그아웃
+
+(이메일, 구글 로그인)
+남은 것 — 대시보드 설정 2개 (코드로는 불가)
+
+1. 구글 로그인 미활성화: Google Cloud Console에서 OAuth 클라이언트 생성 → 승인된 리디렉션 URI에 https://hcmpbpeyhmmismxjkkzv.supabase.co/auth/v1/callback 등록 → Supabase Dashboard > Authentication > Providers > Google에 Client ID/Secret 입력. 코드는 준비돼 있어 켜기만 하면 동작합니다.
+2. 이메일 회원가입이 실제로는 메일 발송에서 막힘: Confirm email이 켜져 있는데 무료 프로젝트 내장 SMTP가 rate limit(over_email_send_rate_limit)입니다. 개발 중에는 Authentication > Sign In / Providers > Email에서 Confirm email을 끄는 것을 권합니다. (참고로 Supabase가 MX 없는 도메인 — example.com 등 — 을 거부하므로 테스트 이메일도 실제 도메인이어야 합니다.)
+
+즉 로그인·로그아웃은 지금 바로 동작하고, 회원가입·구글 로그인은 위 설정 후 동작합니다.


### PR DESCRIPTION
## 작업 내용

`todo.md`의 인증 3종(회원가입 / 로그인 / 로그아웃)을 이메일·구글 방식으로 구현했습니다.

### 구조 — `src/features/auth`

아키텍처 문서의 기능 모듈 구조(`api/ store/ hooks/ utils/ components/`)를 따랐습니다.

| 계층 | 내용 |
|---|---|
| `api/authApi.ts` | signUp / signInWithPassword / signInWithOAuth(google) / signOut / getSession / onAuthStateChange |
| `store/authStore.ts` | Zustand. `loading` / `authenticated` / `unauthenticated` 3상태 |
| `hooks/` | `useAuthSessionSync`(세션 구독), `useAuthMutations`(뮤테이션 4종, TanStack Query) |
| `utils/` | `validateAuthInput`(입력 검증), `authErrorMessage`(Supabase 오류 → 한국어) |
| `components/` | 프레젠테이션 6개 + 컨테이너 4개 |

### 주요 결정

- **세션 상태를 3가지로 구분** — `loading`을 `unauthenticated`와 분리해, 세션 확인 중에 로그인 화면이 잠깐 노출되는 깜빡임을 막았습니다.
- **폼을 프레젠테이션 / 컨테이너로 분리** — 폼은 props만 받고, Supabase 호출은 페이지 컨테이너가 담당합니다. 덕분에 폼 테스트가 네트워크·모킹 없이 돌아갑니다.
- **로그아웃 시 `queryClient.clear()`** — 이전 사용자의 서버 데이터가 캐시에 남지 않도록 했습니다.
- 라우트 `/login` `/signup` `/auth/callback` 추가, 홈에 로그인 상태별 UI(로그아웃 버튼 포함).

### 테스트

Jest 37개 통과 (입력 검증 / 오류 메시지 매핑 / authStore / 폼 상호작용). ESLint·`tsc --noEmit`·`vite build` 모두 통과.

실제 Supabase 프로젝트(서울 리전)를 만들어 REST로 검증했습니다.

- 로그인 200(세션 발급), 틀린 비밀번호 → `invalid_credentials`, 로그아웃 204, 로그아웃 후 refresh token 무효화
- `handle_new_user` 트리거가 `profiles` 자동 생성(매너온도 36.5) 확인

검증 중 오류 매핑 버그를 하나 잡았습니다. 구글 미활성화 응답이 `code: validation_failed` + `msg: provider is not enabled`인데, 덜 구체적인 `validation_failed` 패턴이 먼저 매칭돼 엉뚱한 문구가 나오고 있었습니다. 우선순위를 고치고 실제 관측 페이로드로 테스트를 추가했습니다.

## 머지 전 확인 필요 (대시보드 설정, 코드로는 불가)

1. **구글 로그인 미활성화** — Google Cloud Console에서 OAuth 클라이언트 생성 후 Supabase Dashboard > Authentication > Providers에 등록해야 동작합니다. 리디렉션 URI: `https://<project-ref>.supabase.co/auth/v1/callback`
2. **이메일 회원가입이 메일 발송에서 막힘** — Confirm email이 켜져 있는데 무료 프로젝트 내장 SMTP가 rate limit입니다. 개발 중에는 Confirm email을 끄거나 커스텀 SMTP를 붙여야 합니다.

즉 **로그인·로그아웃은 현재 동작**하고, **회원가입·구글 로그인은 위 설정 후 동작**합니다.

## 참고

`.env.local`(URL·키)은 gitignore되어 포함되지 않았습니다. 로컬에서 받으신 뒤 `.env.example`을 참고해 채워주세요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
