### PR TITLE
fix : 카카오맵 로딩 실패와 재가입 사용자 온보딩 화면 수정

### DIFF
--- a/note.md
+++ b/note.md
@@ -147,6 +147,10 @@ src/features/profile/                동네 "저장"은 profiles의 일이라 �
 `.env.local`의 `VITE_KAKAO_MAP_KEY`에 JavaScript 키를 넣는다.
 **Vite는 `.env.local`을 서버 시작 시 한 번만 읽으므로 값을 바꾸면 dev 서버를 다시 띄워야 한다.**
 
+2번의 도메인은 **포트까지 정확히 일치**해야 한다. 그래서 `vite.config.ts`에서 개발 서버 포트를
+`5173`으로 고정하고 `strictPort: true`를 켰다 — 포트가 밀리면(5174 등) 카카오가 401로 거부하는데,
+화면에는 "카카오 콘솔을 확인하라"는 엉뚱한 문구만 뜬다. 조용히 옮기는 대신 즉시 실패시킨다.
+
 ### 테스트
 
 카카오 SDK는 jsdom에서 로드할 수 없다. `regionApi.ts`가 그 의존성을 가두는 경계이므로

--- a/src/features/profile/components/onboardingPage.tsx
+++ b/src/features/profile/components/onboardingPage.tsx
@@ -4,7 +4,7 @@ import PageSpinner from '../../../shared/ui/pageSpinner';
 import { selectAuthStatus, selectAuthUser, useAuthStore } from '../../auth/store/authStore';
 import { useCompleteOnboardingMutation } from '../hooks/useProfileMutations';
 import { useMyProfileQuery } from '../hooks/useProfileQuery';
-import { isOnboardingComplete, toInitialNickname } from '../utils/onboardingStatus';
+import { isOnboardingComplete, needsRegionOnly, toInitialNickname } from '../utils/onboardingStatus';
 import { toProfileErrorMessage } from '../utils/profileErrorMessage';
 
 /**
@@ -63,6 +63,9 @@ function OnboardingPage() {
       ? toProfileErrorMessage(onboardingMutation.error)
       : null;
 
+  // 이미 가입을 마친 사용자는 동네만 비어 있다. 프로필을 처음부터 다시 정하라고 하면 안 된다.
+  const regionOnly = profile !== undefined && needsRegionOnly(profile);
+
   return (
     <main className="mx-auto flex min-h-screen max-w-screen-sm flex-col justify-center gap-6 p-6">
       <header className="flex flex-col items-center gap-2 text-center">
@@ -70,10 +73,12 @@ function OnboardingPage() {
           🍆 가지마켓
         </span>
         <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-50">
-          시작하기 전에 몇 가지만 알려 주세요
+          {regionOnly ? '거래할 동네를 정해 주세요' : '시작하기 전에 몇 가지만 알려 주세요'}
         </h1>
         <p className="text-sm text-gray-600 dark:text-gray-400">
-          이웃에게 보여질 프로필과 거래할 동네입니다.
+          {regionOnly
+            ? '동네를 정해야 이웃의 물건을 볼 수 있습니다. 나중에 언제든 바꿀 수 있어요.'
+            : '이웃에게 보여질 프로필과 거래할 동네입니다.'}
         </p>
       </header>
 
@@ -93,6 +98,7 @@ function OnboardingPage() {
 
         <OnboardingSteps
           initialNickname={profile === undefined ? '' : toInitialNickname(profile)}
+          regionOnly={regionOnly}
           isPending={onboardingMutation.isPending}
           onComplete={handleComplete}
         />

--- a/src/features/profile/components/onboardingRegionStep.tsx
+++ b/src/features/profile/components/onboardingRegionStep.tsx
@@ -6,7 +6,8 @@ type OnboardingRegionStepProps = {
   isPending: boolean;
   errorMessage?: string;
   onRegionChange(region: Region): void;
-  onBack(): void;
+  /** 없으면 '이전'을 숨긴다. 동네만 고치는 사용자에게는 돌아갈 앞 단계가 없다. */
+  onBack?: () => void;
   onFinish(): void;
 };
 
@@ -25,16 +26,18 @@ function OnboardingRegionStep(props: OnboardingRegionStepProps) {
       />
 
       <div className="flex gap-2">
-        <button
-          type="button"
-          disabled={props.isPending}
-          onClick={props.onBack}
-          className="rounded-lg border border-gray-300 px-4 py-2.5 text-sm font-semibold text-gray-700
-                     transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60
-                     dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800"
-        >
-          이전
-        </button>
+        {props.onBack === undefined ? null : (
+          <button
+            type="button"
+            disabled={props.isPending}
+            onClick={props.onBack}
+            className="rounded-lg border border-gray-300 px-4 py-2.5 text-sm font-semibold text-gray-700
+                       transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60
+                       dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800"
+          >
+            이전
+          </button>
+        )}
         <button
           type="button"
           disabled={props.isPending}

--- a/src/features/profile/components/onboardingSteps.test.tsx
+++ b/src/features/profile/components/onboardingSteps.test.tsx
@@ -37,7 +37,7 @@ const SUYU: Region = {
   coords: { lat: 37.6379, lng: 127.0146 },
 };
 
-function renderSteps(onComplete: jest.Mock, initialNickname = '') {
+function renderSteps(onComplete: jest.Mock, initialNickname = '', regionOnly = false) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
@@ -47,6 +47,7 @@ function renderSteps(onComplete: jest.Mock, initialNickname = '') {
       <QueryClientProvider client={queryClient}>
         <OnboardingSteps
           initialNickname={initialNickname}
+          regionOnly={regionOnly}
           isPending={false}
           onComplete={onComplete}
         />
@@ -121,6 +122,29 @@ describe('OnboardingSteps', function onboardingStepsSuite() {
     renderSteps(jest.fn(), '기존닉네임');
 
     expect(screen.getByLabelText('닉네임')).toHaveValue('기존닉네임');
+  });
+
+  // 이미 가입한 계정에 프로필 설정 화면을 다시 띄우면 안 된다.
+  it('가입을 마친 사용자에게는 프로필 단계를 건너뛰고 동네만 묻는다', function regionOnlyCase() {
+    renderSteps(jest.fn(), '기존닉네임', true);
+
+    expect(screen.getByLabelText('동네 이름으로 찾기')).toBeInTheDocument();
+    expect(screen.queryByLabelText('닉네임')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '이전' })).not.toBeInTheDocument();
+  });
+
+  it('건너뛴 경우에도 기존 닉네임을 그대로 넘긴다', async function regionOnlySubmitCase() {
+    const handleComplete = jest.fn();
+    renderSteps(handleComplete, '기존닉네임', true);
+
+    await pickSuyu();
+    await userEvent.click(screen.getByRole('button', { name: '시작하기' }));
+
+    expect(handleComplete).toHaveBeenCalledWith({
+      nickname: '기존닉네임',
+      avatarFile: null,
+      region: SUYU,
+    });
   });
 
   it('1단계에서는 아직 저장하지 않는다', async function noEarlyWriteCase() {

--- a/src/features/profile/components/onboardingSteps.tsx
+++ b/src/features/profile/components/onboardingSteps.tsx
@@ -16,6 +16,8 @@ export type CompletedOnboardingDraft = ProfileOnboardingValues & { region: Regio
 type OnboardingStepsProps = {
   /** 이미 닉네임이 있는 사용자를 위한 초기값. 임시 닉네임이면 빈 문자열이 온다. */
   initialNickname: string;
+  /** 이미 가입을 마쳐 프로필 단계가 필요 없는 사용자. 동네만 고르게 한다. */
+  regionOnly: boolean;
   isPending: boolean;
   onComplete(draft: CompletedOnboardingDraft): void;
 };
@@ -27,6 +29,8 @@ type OnboardingStepsProps = {
  * 온보딩을 통째로 빠져나가 입력을 날려 버리지 않고 1단계로 돌아가게 하기 위해서다.
  * 값 자체는 컴포넌트 상태에 있으므로 새로고침하면 사라진다 —
  * 그래서 닉네임이 비어 있으면 2단계 주소로 들어와도 1단계로 되돌린다.
+ *
+ * regionOnly면 단계가 하나뿐이라 위 장치가 모두 필요 없다. 쿼리스트링과 상관없이 동네만 보여준다.
  */
 function OnboardingSteps(props: OnboardingStepsProps) {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -38,7 +42,8 @@ function OnboardingSteps(props: OnboardingStepsProps) {
   const [regionError, setRegionError] = useState<string | undefined>(undefined);
 
   const isRegionStep =
-    searchParams.get(STEP_PARAM) === REGION_STEP && draft.nickname.trim().length > 0;
+    props.regionOnly ||
+    (searchParams.get(STEP_PARAM) === REGION_STEP && draft.nickname.trim().length > 0);
 
   function goToRegionStep(values: ProfileOnboardingValues): void {
     setDraft(function mergeProfileValues(previous) {
@@ -74,7 +79,10 @@ function OnboardingSteps(props: OnboardingStepsProps) {
 
   return (
     <div className="flex flex-col gap-6">
-      <OnboardingStepIndicator current={isRegionStep ? 2 : 1} total={TOTAL_STEPS} />
+      {/* 단계가 하나뿐인 사용자에게 "1/1"을 보여 줄 이유가 없다. */}
+      {props.regionOnly ? null : (
+        <OnboardingStepIndicator current={isRegionStep ? 2 : 1} total={TOTAL_STEPS} />
+      )}
 
       {isRegionStep ? (
         <OnboardingRegionStep
@@ -82,7 +90,8 @@ function OnboardingSteps(props: OnboardingStepsProps) {
           isPending={props.isPending}
           errorMessage={regionError}
           onRegionChange={handleRegionChange}
-          onBack={goBackToProfileStep}
+          // 돌아갈 앞 단계가 없으면 '이전' 버튼도 없어야 한다.
+          onBack={props.regionOnly ? undefined : goBackToProfileStep}
           onFinish={handleFinish}
         />
       ) : (

--- a/src/features/profile/utils/onboardingStatus.test.ts
+++ b/src/features/profile/utils/onboardingStatus.test.ts
@@ -1,4 +1,4 @@
-import { isOnboardingComplete, toInitialNickname } from './onboardingStatus';
+import { isOnboardingComplete, needsRegionOnly, toInitialNickname } from './onboardingStatus';
 import type { Region } from '../../region/types';
 import type { Profile } from '../types';
 
@@ -49,5 +49,23 @@ describe('toInitialNickname', function toInitialNicknameSuite() {
 
   it('임시 닉네임과 모양만 비슷한 이름은 지우지 않는다', function lookalikeCase() {
     expect(toInitialNickname(createProfile({ nickname: 'user_hello' }))).toBe('user_hello');
+  });
+});
+
+describe('needsRegionOnly', function needsRegionOnlySuite() {
+  // 동네 설정 기능 이전에 가입한 사용자. 프로필은 이미 정했으니 동네만 물어야 한다.
+  it('가입을 마친 사용자에게는 동네 단계만 보여준다', function legacyUserCase() {
+    expect(needsRegionOnly(createProfile({ region: null }))).toBe(true);
+  });
+
+  it('갓 가입한 사용자는 프로필 단계부터 거친다', function freshUserCase() {
+    expect(needsRegionOnly(createProfile({ onboardedAt: null, region: null }))).toBe(false);
+  });
+
+  // 건너뛰면 트리거가 넣은 임시 닉네임이 그대로 굳는다.
+  it('닉네임이 임시값이면 건너뛰지 않는다', function tempNicknameCase() {
+    expect(
+      needsRegionOnly(createProfile({ nickname: 'user_1a2b3c4d', region: null })),
+    ).toBe(false);
   });
 });

--- a/src/features/profile/utils/onboardingStatus.ts
+++ b/src/features/profile/utils/onboardingStatus.ts
@@ -23,3 +23,16 @@ const TEMP_NICKNAME_PATTERN = /^user_[0-9a-f]{8}$/;
 export function toInitialNickname(profile: Profile): string {
   return TEMP_NICKNAME_PATTERN.test(profile.nickname) ? '' : profile.nickname;
 }
+
+/**
+ * 프로필 단계를 건너뛰고 동네만 고르게 할 사용자인지 판정한다.
+ *
+ * 동네 설정 기능 이전에 가입한 사용자는 onboarded_at과 닉네임이 이미 차 있고 동네만 없다.
+ * 이들에게 닉네임·사진 화면부터 다시 보여주면 "이미 가입한 계정인데 왜 또 프로필을 정하나"가 된다.
+ *
+ * 닉네임이 임시값이면 사용자가 정한 적이 없다는 뜻이라 건너뛰지 않는다 —
+ * 건너뛰면 임시 닉네임이 그대로 굳어 버린다.
+ */
+export function needsRegionOnly(profile: Profile): boolean {
+  return profile.onboardedAt !== null && toInitialNickname(profile).length > 0;
+}

--- a/src/shared/lib/kakaoMapLoader.ts
+++ b/src/shared/lib/kakaoMapLoader.ts
@@ -25,7 +25,13 @@ function toScriptSource(): string {
   return `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${KAKAO_APP_KEY}&libraries=services&autoload=false`;
 }
 
-/** SDK 스크립트를 붙이고 로드 완료를 기다린다. 이미 붙어 있으면 그 요소를 재사용한다. */
+/**
+ * SDK 스크립트를 붙이고 로드 완료를 기다린다.
+ *
+ * 이미 붙어 있는 요소는 재사용하지 않고 지운 뒤 새로 붙인다.
+ * 재사용하면 한 번 실패한 <script>에 리스너를 다는 꼴이 되는데, load도 error도 이미 끝난 뒤라
+ * 다시 발생하지 않아 재시도가 영원히 멈춘다. 동시 호출은 loadPromise가 이미 막고 있다.
+ */
 function appendSdkScript(): Promise<void> {
   return new Promise(function attachScript(resolve, reject): void {
     if (window.kakao?.maps !== undefined) {
@@ -33,10 +39,12 @@ function appendSdkScript(): Promise<void> {
       return;
     }
 
-    const existing = document.getElementById(SCRIPT_ELEMENT_ID);
-    const script =
-      existing !== null ? (existing as HTMLScriptElement) : document.createElement('script');
+    const stale = document.getElementById(SCRIPT_ELEMENT_ID);
+    if (stale !== null) {
+      stale.remove();
+    }
 
+    const script = document.createElement('script');
     script.addEventListener('load', function handleScriptLoad(): void {
       resolve();
     });
@@ -44,12 +52,10 @@ function appendSdkScript(): Promise<void> {
       reject(toLoaderError(KAKAO_LOAD_FAILED_CODE));
     });
 
-    if (existing === null) {
-      script.id = SCRIPT_ELEMENT_ID;
-      script.async = true;
-      script.src = toScriptSource();
-      document.head.appendChild(script);
-    }
+    script.id = SCRIPT_ELEMENT_ID;
+    script.async = true;
+    script.src = toScriptSource();
+    document.head.appendChild(script);
   });
 }
 

--- a/troble.md
+++ b/troble.md
@@ -560,3 +560,104 @@ useMarkRoomRead(roomId, viewerId, countUnreadFromPartner(messages, viewerId));
 **교훈**: 실시간 화면에서 "이미 손에 있는 데이터로 판단할 수 있는 것"을 굳이 서버에 다시 묻지 않는다.
 왕복을 하나 끼우면 그 왕복이 실패하거나 늦는 만큼 화면 전체가 늦어진다.
 그리고 이 종류는 **단위 테스트로는 절대 안 잡힌다** — 두 사용자가 동시에 있어야 드러난다.
+
+---
+
+## 재접속 (2026-08-03)
+
+### 1. 잘 되던 카카오맵이 갑자기 거부됨 — 원인은 vite가 바꾼 포트였다
+
+**증상**: 동네 설정에서 "지도 서비스를 불러오지 못했습니다. 카카오 콘솔에서 카카오맵이
+활성화되어 있는지, 이 주소가 도메인으로 등록되어 있는지 확인해 주세요."가 떴다.
+콘솔 설정은 아무것도 건드린 적이 없고, 전날까지 잘 되던 기능이다.
+
+**원인 찾기**: 문구가 짚어 준 두 가지를 `Referer`를 바꿔 가며 확인했다.
+
+```bash
+for ref in "http://localhost:5173/" "http://localhost:5174/"; do
+  curl -s -o /dev/null -w "%{http_code}\n" -H "Referer: $ref" \
+    "https://dapi.kakao.com/v2/maps/sdk.js?appkey=${KEY}&libraries=services&autoload=false"
+done
+# 5173 -> 200
+# 5174 -> 401
+```
+
+키도 카카오맵 활성화도 멀쩡했다. **주소가 달랐다.**
+5173 포트가 이미 점유돼 있어서 vite가 말없이 **5174**로 올린 상태였고,
+카카오 콘솔에 등록된 도메인은 `http://localhost:5173` 하나뿐이라 401이 났다.
+카카오의 도메인 검사는 포트까지 정확히 일치해야 한다.
+
+**해결**: 포트를 고정하고, 점유됐을 때 조용히 옮기는 대신 즉시 실패하게 했다.
+
+```ts
+// vite.config.ts
+server: { port: 5173, strictPort: true },
+```
+
+`strictPort`가 없으면 "포트가 밀렸다"는 사실이 로그 한 줄로 지나가고,
+증상은 엉뚱하게도 **카카오 콘솔 설정 문제처럼** 보인다.
+같은 주소가 Supabase Redirect URLs에도 등록돼 있어 인증까지 함께 깨질 수 있다.
+
+**교훈**: 외부 서비스에 **도메인을 등록해 쓰는 앱은 개발 서버 포트가 설정값의 일부**다.
+자동으로 옮겨 주는 편의 기능이 오히려 원인을 숨긴다. 고정하고 실패시키는 편이 낫다.
+
+---
+
+### 2. 한 번 실패한 SDK 로딩은 재시도해도 영영 끝나지 않았다
+
+**증상**: 위 문제를 쫓다가 발견했다. 로딩에 실패한 뒤 "다시 시도"를 눌러도
+오류도 성공도 없이 버튼이 계속 "불러오는 중"에 머물렀다.
+
+**원인**: 실패한 `<script>` 요소를 **재사용**했다.
+
+```ts
+const existing = document.getElementById(SCRIPT_ELEMENT_ID);
+const script = existing !== null ? existing : document.createElement('script');
+script.addEventListener('load', resolve);
+script.addEventListener('error', reject);   // ← 이미 끝난 요소라 둘 다 다시 안 온다
+```
+
+`load`/`error`는 일회성 이벤트다. 이미 발생을 마친 요소에 리스너를 새로 달면
+resolve도 reject도 되지 않아 Promise가 영원히 pending으로 남는다.
+로더는 실패 시 `loadPromise`를 null로 되돌려 재시도를 허용하는데,
+정작 그 재시도가 죽은 요소를 붙잡고 있었다.
+
+**해결**: 남아 있는 요소는 지우고 새로 붙인다. 동시 호출은 `loadPromise`가 이미 막고 있으므로
+요소 재사용으로 중복을 막을 이유가 없었다.
+
+```ts
+const stale = document.getElementById(SCRIPT_ELEMENT_ID);
+if (stale !== null) {
+  stale.remove();
+}
+const script = document.createElement('script');
+```
+
+**교훈**: 일회성 이벤트를 기다리는 캐시는 **성공 경로만 보면 멀쩡해 보인다.**
+"실패한 뒤 다시 시도"까지 따라가 봐야 드러난다.
+
+---
+
+### 3. 이미 가입한 계정에 프로필 설정 화면이 다시 떴다
+
+**증상**: 가입돼 있는 구글 계정으로 접속했는데 닉네임·사진부터 다시 정하라는 화면이 나왔다.
+
+**원인**: 동네 설정 기능 이전에 가입한 행은 `onboarded_at`과 닉네임은 차 있고 동네만 비어 있다.
+`isOnboardingComplete`가 이들을 온보딩으로 되돌리는 것 자체는 **의도한 동작**이지만
+(그래야 동네를 정할 기회가 생긴다), 온보딩 화면이 **항상 1단계부터** 시작하는 것이 문제였다.
+이미 정한 닉네임을 다시 물으니 "가입이 안 된 건가?"로 보인다.
+
+**해결**: 판정을 하나 더 두어 동네 단계만 보여준다.
+
+```ts
+// profile/utils/onboardingStatus.ts
+export function needsRegionOnly(profile: Profile): boolean {
+  return profile.onboardedAt !== null && toInitialNickname(profile).length > 0;
+}
+```
+
+닉네임이 임시값(`user_1a2b3c4d`)이면 사용자가 정한 적이 없다는 뜻이라 건너뛰지 않는다.
+건너뛰면 트리거가 넣은 임시 닉네임이 그대로 굳어 버린다.
+
+**교훈**: 마이그레이션으로 생긴 "중간 상태"의 사용자는 **가드를 통과시키는 것만으로 끝이 아니다.**
+그 다음에 보게 될 화면이 자신의 상태에 맞는지까지 봐야 한다.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,4 +5,9 @@ import tailwindcss from '@tailwindcss/vite';
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  // 카카오 콘솔(플랫폼 > Web)과 Supabase Redirect URLs에 등록한 주소는 http://localhost:5173 하나뿐이다.
+  // 포트는 정확히 일치해야 해서, 5173이 막혔을 때 vite가 5174로 조용히 옮기면
+  // 카카오 SDK가 401로 거부되고 화면에는 "지도 서비스를 불러오지 못했습니다"만 뜬다.
+  // strictPort로 조용히 옮기는 대신 즉시 실패시켜 원인이 드러나게 한다.
+  server: { port: 5173, strictPort: true },
 });


### PR DESCRIPTION
## 배경

가입돼 있는 계정으로 접속했는데 동네를 다시 등록하라는 화면이 떴고, 동네를 고르려 하니 "지도 서비스를 불러오지 못했습니다"까지 겹쳤다.

## 1. 카카오맵이 거부된 진짜 원인 — 포트

오류 문구가 짚어 준 두 가지(카카오맵 활성화, 도메인 등록)는 둘 다 멀쩡했다. `Referer`를 바꿔가며 SDK를 직접 확인했다.

```
http://localhost:5173/  -> 200
http://localhost:5174/  -> 401
```

이 프로젝트의 vite 서버가 두 개 떠 있었고, 예전 세션의 것이 5173을 잡고 있어 현재 서버가 말없이 5174로 밀린 상태였다. 카카오 콘솔에 등록된 도메인은 `http://localhost:5173` 하나뿐이고 도메인 검사는 **포트까지 정확히 일치**해야 한다.

- `vite.config.ts` — `server: { port: 5173, strictPort: true }`

자동으로 옮겨 주는 편의 기능이 원인을 숨겼다. 같은 주소가 Supabase Redirect URLs에도 등록돼 있어 방치하면 인증까지 함께 깨진다.

## 2. 실패한 SDK 로딩이 재시도되지 않던 버그

`load`/`error`는 일회성 이벤트다. 실패한 `<script>` 요소를 재사용하며 리스너를 새로 달면 둘 다 다시 오지 않아 Promise가 영원히 pending으로 남는다. 로더는 실패 시 재시도를 허용하는데 정작 그 재시도가 죽은 요소를 붙잡고 있었다.

- `shared/lib/kakaoMapLoader.ts` — 남아 있는 요소를 지우고 새로 붙인다. 동시 호출은 `loadPromise`가 이미 막고 있어 요소 재사용으로 중복을 막을 이유가 없었다.

## 3. 이미 가입한 계정에 프로필 설정 화면이 다시 뜨던 문제

동네 설정 기능 이전에 가입한 행은 `onboarded_at`과 닉네임이 차 있고 동네만 비어 있다. 온보딩으로 되돌리는 것 자체는 의도한 동작이지만, 화면이 **항상 1단계부터** 시작해 이미 정한 닉네임을 다시 물었다.

- `profile/utils/onboardingStatus.ts` — `needsRegionOnly()` 추가
- `onboardingSteps.tsx` / `onboardingRegionStep.tsx` — `regionOnly`면 단계 표시와 '이전' 버튼을 숨긴다
- `onboardingPage.tsx` — 제목·설명도 동네 전용 문구로

닉네임이 임시값(`user_1a2b3c4d`)이면 사용자가 정한 적이 없다는 뜻이라 건너뛰지 않는다. 건너뛰면 트리거가 넣은 임시 닉네임이 그대로 굳는다. 저장 시 기존 닉네임은 그대로, `avatarFile`은 null이라 기존 사진도 보존된다.

## 검증

- `npx tsc --noEmit`, `npx eslint .` 통과
- `npx jest` — 40 suites / 284 tests 통과 (신규 5개: `needsRegionOnly` 3, 프로필 단계 건너뛰기 2)
- 브라우저에서 동네 선택·지도 검색 동작 확인

문서는 `troble.md`(3건)와 `note.md`(카카오 사전 준비에 포트 고정 이유)에 반영했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
