### PR TITLE
feature : 알림 구현

### DIFF
--- a/note.md
+++ b/note.md
@@ -1802,3 +1802,191 @@ chat/utils/chatErrorMessage    차단 거절 문구 둘 추가
   이 앱 밖의 일이다
 - **차단 사유 남기기** — `blocks`에 사유 칸이 없다. 차단은 신고와 달리 남에게 설명할 일이 아니다
 - **자동 차단 · 신고 누적 제재** — 신고가 쌓이면 자동으로 가리는 규칙. 기준을 사람이 정해야 한다
+
+---
+
+## 알림 (2026-08-05)
+
+`todo.md` 7단계. 여기는 **만들 것이 없는 단계에 가까웠다** — `notifications` 테이블도 정책도
+0001부터 있었고, 트리거 둘이 **이미 행을 쌓고 있었다.**
+
+```sql
+-- 0008 on_message_insert : 채팅·가격제안이 들어올 때마다
+insert into notifications (user_id, type, payload)
+values (v_recipient, ...,  jsonb_build_object('room_id', new.room_id, 'message_id', new.id));
+
+-- 0001 recalc_manner_temp : 후기가 들어올 때마다
+insert into notifications (user_id, type, payload)
+values (new.reviewee_id, 'review', jsonb_build_object('post_id', ..., 'review_id', new.id));
+```
+
+없던 것은 **읽는 쪽**이다. 알림이 쌓이기만 하고 아무도 보지 않는 상태였다.
+
+### 무엇을 만들었나
+
+1. **`/notifications`** — 알림 목록. 무한 스크롤, 안 읽은 줄 표시, "모두 읽음".
+2. **홈 헤더의 종 + 안 읽은 배지** — 마이페이지 메뉴에도 링크를 뒀다(배지는 없이).
+3. **`fetch_notifications`** — `payload jsonb`의 id를 서버가 풀어 상대·게시물·미리보기까지 준다.
+4. **Realtime 구독** — `notifications`가 publication에 아예 없었다.
+5. **`notificationText.ts`** — payload를 사람의 말과 이동 경로로 바꾸는 순수 함수.
+6. **차단하면 그 사람에게서 온 알림도 지운다** — 6단계가 남긴 구멍이다.
+
+마이그레이션은 `0015_notification.sql`. `todo.md`는 "댓글·찜 알림을 넣을 때만 필요"라고
+적어 뒀지만, 실제로는 그것 말고도 손댈 곳이 넷이었다(아래 1·2·4번).
+
+### 설계 결정
+
+#### 1. Realtime publication에 `notifications`가 없었다
+
+`todo.md`는 "Realtime 구독은 `useChatRealtime.ts` 패턴을 그대로 따른다"고만 적어 뒀다.
+그런데 0008이 publication에 넣은 것은 `messages`와 `chat_rooms` 둘뿐이다.
+
+```sql
+alter publication supabase_realtime add table notifications;
+```
+
+이 한 줄이 없으면 **구독은 조용히 성공하고 이벤트만 영원히 오지 않는다.** 실패로 보이지 않아
+더 찾기 어려운 종류의 누락이다. `replica identity full`은 걸지 않았다 — 그것이 필요한 것은
+update의 이전 행을 볼 때인데(메시지 읽음 표시가 그랬다) 알림은 insert만 구독한다.
+
+#### 2. `payload jsonb`는 누가 푸는가 — 서버
+
+payload에 들어 있는 것은 id뿐이다(`{"room_id": 9, "message_id": 23}`). 화면이 쓸 문구
+("가지팔이님이 메시지를 보냈어요")를 만들려면 보낸 사람의 닉네임과 메시지 내용이 필요하다.
+
+이대로 내려보내면 알림 한 줄마다 메시지·방·프로필을 따로 조회하게 된다. 스무 줄이면 수십 번이다.
+그래서 `fetch_notifications`가 한 번에 푼다 — 0009의 마이페이지 목록, 0013의 `fetch_user_reviews`가
+제목·닉네임을 함께 내려준 것과 같은 판단이다.
+
+푸는 방법은 `left join` 넷이다. 타입별 `case`로 갈래를 나누지 않았다 — payload에 그 키가 없으면
+`->>`가 null을 주고 join이 그냥 비어 남는다.
+
+```sql
+left join messages   m     on m.id  = (n.payload ->> 'message_id')::bigint
+left join chat_rooms cr    on cr.id = m.room_id
+left join reviews    rv    on rv.id = (n.payload ->> 'review_id')::bigint
+left join posts      p     on p.id  = coalesce(cr.post_id, rv.post_id,
+                                               (n.payload ->> 'post_id')::bigint)
+left join profiles   actor on actor.id = coalesce(m.sender_id, rv.reviewer_id)
+```
+
+`security invoker`(기본)로 뒀다. join하는 `messages`·`chat_rooms`에 각자의 select 정책이
+그대로 걸리는데, 알림을 받은 사람은 그 방의 참여자라 통과한다. 우회할 이유가 없으면 우회하지 않는다.
+
+#### 3. 문구와 경로는 화면이 아니라 순수 함수가 만든다
+
+서버가 값을 풀어 줘도 "그래서 뭐라고 쓸 것인가"는 남는다. 이 분기를 컴포넌트 안에 두면
+어떤 알림이 어디로 가는지 확인하려고 화면을 그려야 한다.
+
+```ts
+export function toNotificationView(notification: AppNotification, viewerId: string): NotificationView
+```
+
+`viewerId`를 받는 이유는 후기 하나 때문이다 — **받은 후기는 내 프로필에 붙는다.** 후기 한 건만
+여는 화면이 없어서 알림 행만 봐서는 갈 곳을 알 수 없다.
+
+갈 곳이 없으면(`to === null`) 그 줄은 링크가 아니라 그냥 줄로 그린다. 눌러도 아무 일이 없는
+링크를 남겨 두면 "눌렀는데 왜 안 가지"가 된다.
+
+`comment`·`like`도 함께 다뤘다. **이 값을 넣는 트리거는 아직 없다**(댓글·찜 기능 자체가 없다).
+그래도 enum에 있는 값이라, 나중에 트리거만 더하면 화면은 그대로 굴러간다.
+
+#### 4. `notifications_update`가 무엇이든 바꿀 수 있었다
+
+0001의 정책은 `auth.uid() = user_id` 하나뿐이다. 내 알림이면 **payload까지 바꿀 수 있다는 뜻**이라
+알림이 가리키는 대상을 사후에 바꿔치기할 수 있었다.
+
+`messages`에 `guard_message_update`(0008)를 둔 것과 같은 이유로 컬럼을 잠갔다. 화면이 보내는
+update는 `is_read` 하나뿐이라 잃는 것이 없다. 덕분에 읽음 처리에 RPC가 필요 없다 —
+채팅의 `markRoomRead`와 같이 평범한 update로 충분하다.
+
+#### 5. 배지는 왜 목록을 나눠 쓰지 않는가
+
+채팅 배지(`useUnreadChatCount`)는 채팅 목록 쿼리를 그대로 합쳐서 낸다. 알림은 그럴 수 없다 —
+목록이 무한 스크롤이라 첫 페이지만 받은 상태에서는 **20까지밖에 못 센다.** 방 목록은 페이징 없이
+통째로 오기 때문에 가능했던 일이다.
+
+그래서 `count_unread_notifications()` RPC를 따로 뒀고, 부분 인덱스(`where is_read = false`)를
+그 동선에 깔았다.
+
+배지를 **한 곳에만** 두는 것은 채팅과 같다. 홈 헤더의 종 하나뿐이고 마이페이지 메뉴에는 숫자가
+없다 — 같은 숫자를 두 곳에 그리면 한쪽만 늦게 갱신될 때 어느 쪽이 맞는지 알 수 없다.
+
+탭바에 여섯 번째 자리를 만들지 않은 이유는 따로 있다. 알림은 "하러 가는 곳"이 아니라
+"왔을 때 가는 곳"이라 다섯 칸을 여섯으로 좁힐 만큼 늘 필요하지 않다.
+
+#### 6. Realtime은 캐시에 꽂지 않고 다시 읽게 한다
+
+`useChatRoomRealtime`은 payload를 캐시에 직접 얹는다. 알림은 그럴 수 없다 — Realtime이 주는 것은
+`notifications` 행 그대로(id가 든 payload)인데 목록이 쓰는 모양은 서버가 join해서 푼 것이라
+둘이 다르다. 앞에서 풀어 준 값을 화면에서 다시 만들 방법이 없다.
+
+그래서 "무언가 왔다"만 신호로 쓰고 무효화한다 — `useChatRoomsRealtime`이 방 목록에 한 것과 같다.
+
+구독은 홈 헤더의 종에서 건다. 홈은 앱을 켜면 처음 닿는 화면이라, 알림 화면을 열지 않아도
+새 알림이 오면 숫자가 곧바로 바뀐다.
+
+#### 7. 읽음 표시는 보내기 전에 캐시부터 고친다
+
+알림을 누르면 곧바로 다른 화면으로 넘어간다. 응답을 기다렸다 고치면 **그 결과를 받을 화면이 이미
+없다.** 그래서 `onMutate`에서 캐시를 먼저 고치고, 실패해도 되돌리지 않는다 — 잃는 것이 굵은 글씨
+하나뿐이고 다음 조회가 서버 값으로 덮는다.
+
+"모두 읽음"은 반대다. 화면에 머무른 채 누르는 버튼이라 `onSuccess`에서 고친다. 실패하면 굵은
+글씨가 그대로 남아 다시 누를 수 있다.
+
+### 파일 구성
+
+```
+supabase/migrations/
+└─ 0015_notification.sql       publication에 notifications 추가
+                               guard_notification_update
+                               fetch_notifications · count_unread_notifications
+                               notifications_unread_idx
+                               purge_blocked_notifications (blocks after insert)
+
+notification/                  (여태 .gitkeep만 있던 폴더)
+├─ api/notificationApi.ts      fetchNotifications · fetchUnreadNotificationCount
+│                              markNotificationRead · markAllNotificationsRead
+│                              subscribeToMyNotifications
+├─ hooks/useNotificationQueries.ts    목록(무한) · 안 읽은 수
+├─ hooks/useNotificationRealtime.ts   insert만 구독하고 무효화
+├─ hooks/useNotificationMutations.ts  읽음 하나 · 모두 읽음
+├─ utils/notificationText.ts   payload → 문구·경로 (순수 함수)
+├─ utils/notificationCache.ts  읽음 표시를 캐시에 반영하는 순수 함수들
+├─ utils/notificationCursor.ts
+└─ components/                 notificationPage · notificationList
+                               · notificationListItem · notificationBellLink
+
+app/router.tsx                 /notifications 추가 (탭바 안)
+browse/components/homePage     MemberGreeting 오른쪽에 종
+profile/components/myPageMenu  알림 항목 추가(배지 없음)
+block/hooks/useBlockMutations  ['notifications'] 무효화 추가
+```
+
+### 검증
+
+`npx jest` 77 스위트 · 542건 통과(신규 4 스위트 23건). `tsc --noEmit`·`eslint` 무경고,
+`vite build` 성공.
+
+실제 DB에서 `set local role authenticated` + `request.jwt.claims`로 사용자를 흉내 내 확인했다.
+
+- `fetch_notifications()` → 쌓여 있던 채팅 알림 1건이 **닉네임·게시물 제목·미리보기까지 채워져** 나온다
+  (`actor_nickname`, `post_title: '아이패드'`, `preview: 'dwedwd'`)
+- `count_unread_notifications()` → `1`
+- payload를 바꾸는 update → `23514 알림은 읽음 표시만 바꿀 수 있습니다.`
+- `update ... set is_read = true where is_read = false`("모두 읽음") → 성공, 안 읽은 수 `1 → 0`
+  (`user_id`로 좁히지 않아도 RLS가 내 행만 건드린다)
+- `purge_blocked_notifications`의 delete 조건을 select로 돌려 → 두 사람 사이의 알림 1건이 잡힌다
+- `pg_publication_tables` → `chat_rooms`, `messages`, `notifications`
+
+### 이번 범위 밖
+
+- **댓글·찜 알림** — enum에는 있지만 넣는 트리거가 없다. 댓글 기능 자체가 없어서다.
+  `notificationText`는 두 타입을 이미 다루므로 트리거만 더하면 화면은 그대로 굴러간다
+- **알림 지우기 · 알림 설정** — 목록에서 개별 삭제, 종류별 on/off. 당근에는 있다.
+  `notifications`에 delete 정책을 열어야 하고 설정은 `profiles`에 칸이 필요하다
+- **푸시 알림** — 앱이 꺼져 있을 때 오는 알림. 웹 푸시는 서비스 워커·VAPID 키·구독 저장이 필요해
+  이 단계와 무게가 다르다
+- **차단 해제 시 알림 되살리기** — 지운 것이라 돌아오지 않는다. 알림은 "그때 알려 주는 것"이라
+  되돌릴 값이 아니라고 봤다(방과 대화는 0014대로 그대로 돌아온다)

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -8,6 +8,7 @@ import HomePage from '../features/browse/components/homePage';
 import SearchPage from '../features/browse/components/searchPage';
 import ChatRoomListPage from '../features/chat/components/chatRoomListPage';
 import ChatRoomPage from '../features/chat/components/chatRoomPage';
+import NotificationPage from '../features/notification/components/notificationPage';
 import NewPostPage from '../features/post/components/newPostPage';
 import PostDetailPage from '../features/post/components/postDetailPage';
 import PostEditPage from '../features/post/components/postEditPage';
@@ -58,6 +59,18 @@ export const router = createBrowserRouter([
         element: (
           <RequireOnboarding>
             <ChatRoomListPage />
+          </RequireOnboarding>
+        ),
+      },
+      {
+        // 알림도 탭바 안이다. 홈의 종에서도 오고 마이페이지에서도 와서 돌아갈 곳이
+        // 하나로 정해지지 않는다 — `← 어디로` 대신 탭바가 그 자리를 맡는다.
+        path: '/notifications',
+        element: (
+          <RequireOnboarding>
+            <RequireMember>
+              <NotificationPage />
+            </RequireMember>
           </RequireOnboarding>
         ),
       },

--- a/src/features/block/hooks/useBlockMutations.ts
+++ b/src/features/block/hooks/useBlockMutations.ts
@@ -12,7 +12,11 @@ import { blockUser, unblockUser } from '../api/blockApi';
  * 차단은 "표시를 남기는 일"이 아니라 "안 보이게 하는 일"이라 목록이 전부 달라진다.
  *   · 홈·검색      상대의 글이 빠진다 (0014의 search_posts)
  *   · 채팅         상대와의 방이 빠진다 (fetch_chat_rooms → 탭바 배지까지)
+ *   · 알림         상대에게서 온 알림이 지워진다 (0015의 purge_blocked_notifications)
  *   · 차단 목록    방금 넣거나 뺀 사람이 반영된다
+ *
+ * 알림만 되돌아오지 않는다 — 지워진 것이라 해제해도 그대로다. 그래도 같은 갱신에 두는 이유는
+ * 해제한 뒤 목록이 어떻게 보이는지가 화면의 몫이 아니라 서버의 답이기 때문이다.
  *
  * 해제도 같은 목록을 되돌리므로 두 뮤테이션이 같은 갱신을 쓴다.
  * 마이페이지 목록(`['my']`)은 건드리지 않는다 — 찜·최근 본 글은 내가 남긴 흔적이라
@@ -24,6 +28,7 @@ function invalidateBlockAffectedQueries(queryClient: QueryClient): void {
   queryClient.invalidateQueries({ queryKey: ['posts', 'search'] });
   queryClient.invalidateQueries({ queryKey: ['chatRooms'] });
   queryClient.invalidateQueries({ queryKey: ['chatRoom'] });
+  queryClient.invalidateQueries({ queryKey: ['notifications'] });
 }
 
 export function useBlockUserMutation(

--- a/src/features/browse/components/homePage.tsx
+++ b/src/features/browse/components/homePage.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import NeighborhoodPostList from './neighborhoodPostList';
 import { selectAuthStatus, selectAuthUser, useAuthStore } from '../../auth/store/authStore';
+import NotificationBellLink from '../../notification/components/notificationBellLink';
 import ProfileAvatar from '../../profile/components/profileAvatar';
 import { useMyProfileQuery } from '../../profile/hooks/useProfileQuery';
 import type { Profile } from '../../profile/types';
@@ -38,12 +39,15 @@ function GuestActions() {
  *
  * 채팅 입구는 탭바로 옮겼다. 안 읽은 배지도 그리로 따라갔다 —
  * 같은 숫자를 두 곳에 그리면 한쪽만 늦게 갱신될 때 어느 쪽이 맞는지 알 수 없다.
+ *
+ * 알림 종은 반대로 여기 남는다. 탭바는 다섯 칸으로 이미 좁고, 알림은 "하러 가는 곳"이 아니라
+ * "왔을 때 가는 곳"이라 늘 자리를 차지할 이유가 적다. 배지가 한 곳뿐인 것은 채팅과 같다.
  */
-function MemberGreeting(props: { profile: Profile | undefined }) {
+function MemberGreeting(props: { profile: Profile | undefined; viewerId: string }) {
   const profile = props.profile;
 
   return (
-    <div className="flex w-full items-center gap-3">
+    <div className="flex w-full items-center justify-between gap-3">
       <div className="flex min-w-0 items-center gap-3">
         <Link to="/my" aria-label="마이페이지" className="shrink-0">
           <ProfileAvatar
@@ -67,6 +71,8 @@ function MemberGreeting(props: { profile: Profile | undefined }) {
           </Link>
         </div>
       </div>
+
+      <NotificationBellLink viewerId={props.viewerId} />
     </div>
   );
 }
@@ -88,7 +94,9 @@ function HomePage() {
           <p className="text-gray-600 dark:text-gray-300">세션을 확인하는 중입니다…</p>
         ) : null}
 
-        {isMember && user !== null ? <MemberGreeting profile={profileQuery.data} /> : null}
+        {isMember && user !== null ? (
+          <MemberGreeting profile={profileQuery.data} viewerId={user.id} />
+        ) : null}
 
         {/* 검색은 비로그인도 쓸 수 있어 로그인 여부와 상관없이 보여준다. */}
         <Link

--- a/src/features/notification/api/notificationApi.ts
+++ b/src/features/notification/api/notificationApi.ts
@@ -1,0 +1,149 @@
+import { supabase } from '../../../shared/lib/supabaseClient';
+import type { AppNotification, NotificationCursor, NotificationType } from '../types';
+
+/** 알림 한 페이지 크기. 서버(0015)가 50으로 한 번 더 막는다. */
+export const NOTIFICATIONS_PAGE_SIZE = 20;
+
+type NotificationRow = {
+  id: number;
+  type: NotificationType;
+  is_read: boolean;
+  created_at: string;
+  actor_id: string | null;
+  actor_nickname: string | null;
+  actor_avatar_url: string | null;
+  room_id: number | null;
+  post_id: number | null;
+  post_title: string | null;
+  preview: string | null;
+  offer_amount: number | null;
+};
+
+function toAppNotification(row: NotificationRow): AppNotification {
+  return {
+    id: row.id,
+    type: row.type,
+    isRead: row.is_read,
+    createdAt: row.created_at,
+    actorId: row.actor_id,
+    actorNickname: row.actor_nickname,
+    actorAvatarUrl: row.actor_avatar_url,
+    roomId: row.room_id,
+    postId: row.post_id,
+    postTitle: row.post_title,
+    preview: row.preview,
+    offerAmount: row.offer_amount,
+  };
+}
+
+/**
+ * 내 알림 한 페이지.
+ *
+ * 누구의 것인지 보내지 않는다 — 서버가 `auth.uid()`로 판단한다(마이페이지 목록·후기와 같다).
+ */
+export async function fetchNotifications(
+  cursor: NotificationCursor | null,
+): Promise<AppNotification[]> {
+  const { data, error } = await supabase.rpc('fetch_notifications', {
+    p_cursor_at: cursor?.createdAt ?? null,
+    p_cursor_id: cursor?.id ?? null,
+    p_limit: NOTIFICATIONS_PAGE_SIZE,
+  });
+
+  if (error !== null) {
+    throw error;
+  }
+
+  return (data as NotificationRow[]).map(toAppNotification);
+}
+
+/** 안 읽은 알림 수. 홈 헤더 배지가 쓴다. */
+export async function fetchUnreadNotificationCount(): Promise<number> {
+  const { data, error } = await supabase.rpc('count_unread_notifications');
+
+  if (error !== null) {
+    throw error;
+  }
+
+  return data as number;
+}
+
+/**
+ * 알림 하나를 읽음으로 표시한다.
+ *
+ * RPC가 필요 없다 — `notifications_update`(0001)가 본인 것만 허용하고
+ * `guard_notification_update`(0015)가 `is_read` 말고는 못 바꾸게 막는다.
+ * 채팅의 `markRoomRead`와 같은 이유로 평범한 update로 충분하다.
+ *
+ * `is_read = false` 조건은 이미 읽은 알림을 헛되이 다시 쓰지 않기 위한 것이다.
+ * 걸려서 한 행도 안 바뀌어도 오류가 아니다 — 이미 원하는 상태이기 때문이다.
+ */
+export async function markNotificationRead(notificationId: number): Promise<void> {
+  const { error } = await supabase
+    .from('notifications')
+    .update({ is_read: true })
+    .eq('id', notificationId)
+    .eq('is_read', false);
+
+  if (error !== null) {
+    throw error;
+  }
+
+  return undefined;
+}
+
+/**
+ * 안 읽은 알림을 모두 읽음으로 표시한다.
+ *
+ * 범위를 `user_id`로 좁히지 않는다 — RLS가 이미 내 행 말고는 손대지 못하게 한다.
+ * 여기서 한 번 더 좁히면 "정책이 규칙의 주인"이라는 약속이 흐려지고,
+ * 화면이 들고 있는 사용자 id가 낡았을 때 조용히 아무것도 안 하는 길이 생긴다.
+ */
+export async function markAllNotificationsRead(): Promise<void> {
+  const { error } = await supabase
+    .from('notifications')
+    .update({ is_read: true })
+    .eq('is_read', false);
+
+  if (error !== null) {
+    throw error;
+  }
+
+  return undefined;
+}
+
+/**
+ * 내게 오는 새 알림을 구독한다.
+ *
+ * insert만 본다. update(읽음)는 누른 본인의 화면에서 일어나므로 뮤테이션이 그 자리에서
+ * 캐시를 고치면 되고, 서버가 되돌려 줄 이유가 없다 — 그래서 0015는 `replica identity full`도
+ * 걸지 않았다.
+ *
+ * 필터를 걸 수 있다. 채팅방 목록(`subscribeToMyChatRooms`)은 "내가 참여한 방"이 컬럼 하나로
+ * 표현되지 않아 필터 없이 열고 RLS에 맡겼지만, 알림은 `user_id`가 곧 나다. 필터를 걸어 두면
+ * 남의 알림이 서버에서 걸러져 소켓으로 아예 오지 않는다.
+ *
+ * supabase를 아는 자리를 api/ 한 곳에 가둬 두는 규칙은 여기도 같다 — 훅이 직접 채널을 열면
+ * 화면 테스트가 import.meta에 닿아 로드 단계에서 죽는다(troble.md #5).
+ */
+export function subscribeToMyNotifications(viewerId: string, onInsert: () => void): () => void {
+  const channel = supabase
+    .channel(`notifications-${viewerId}`)
+    .on(
+      'postgres_changes',
+      {
+        event: 'INSERT',
+        schema: 'public',
+        table: 'notifications',
+        filter: `user_id=eq.${viewerId}`,
+      },
+      function handleInsert(): void {
+        onInsert();
+      },
+    )
+    .subscribe();
+
+  return function unsubscribe(): void {
+    void supabase.removeChannel(channel);
+  };
+}

--- a/src/features/notification/components/notificationBellLink.tsx
+++ b/src/features/notification/components/notificationBellLink.tsx
@@ -1,0 +1,57 @@
+import { Link } from 'react-router-dom';
+import { useUnreadNotificationCountQuery } from '../hooks/useNotificationQueries';
+import { useNotificationsRealtime } from '../hooks/useNotificationRealtime';
+
+/** 999를 넘으면 숫자보다 "많다"는 사실이 중요해진다(탭바 배지와 같은 기준). */
+const MAX_UNREAD_LABEL = 999;
+
+function toUnreadLabel(count: number): string {
+  return count > MAX_UNREAD_LABEL ? `${MAX_UNREAD_LABEL}+` : String(count);
+}
+
+type NotificationBellLinkProps = {
+  viewerId: string;
+};
+
+/**
+ * 알림으로 가는 종. 홈 헤더에 놓는다.
+ *
+ * 탭바에 여섯 번째 자리를 만들지 않았다. 다섯 칸도 좁고, 알림은 "하러 가는 곳"이 아니라
+ * "왔을 때 가는 곳"이라 늘 자리를 차지할 이유가 적다.
+ *
+ * 배지를 한 곳에만 두는 것은 채팅과 같은 이유다 — 같은 숫자를 두 곳에 그리면 한쪽만 늦게
+ * 갱신될 때 어느 쪽이 맞는지 알 수 없다(homePage의 MemberGreeting 주석 참고).
+ *
+ * 구독은 여기서 건다. 홈은 앱을 켜면 처음 닿는 화면이라, 알림 화면을 열지 않아도
+ * 새 알림이 오면 숫자가 곧바로 바뀐다.
+ */
+function NotificationBellLink(props: NotificationBellLinkProps) {
+  const unreadQuery = useUnreadNotificationCountQuery(props.viewerId);
+  useNotificationsRealtime(props.viewerId);
+
+  const unreadCount = unreadQuery.data ?? 0;
+
+  return (
+    <Link
+      to="/notifications"
+      aria-label={unreadCount === 0 ? '알림' : `알림, 안 읽음 ${unreadCount}개`}
+      className="relative shrink-0 rounded-full p-2 text-xl leading-none transition
+                 hover:bg-gray-100 dark:hover:bg-gray-800"
+    >
+      {/* 아이콘 자체는 aria-label이 대신 읽히므로 감춘다. */}
+      <span aria-hidden="true">🔔</span>
+
+      {unreadCount === 0 ? null : (
+        <span
+          aria-hidden="true"
+          className="absolute right-0 top-0 rounded-full bg-emerald-600 px-1.5 py-0.5
+                     text-[10px] font-semibold leading-none text-white"
+        >
+          {toUnreadLabel(unreadCount)}
+        </span>
+      )}
+    </Link>
+  );
+}
+
+export default NotificationBellLink;

--- a/src/features/notification/components/notificationList.tsx
+++ b/src/features/notification/components/notificationList.tsx
@@ -1,0 +1,75 @@
+import NotificationListItem from './notificationListItem';
+import { useInfiniteScroll } from '../../../shared/hooks/useInfiniteScroll';
+import type { NotificationsQueryResult } from '../hooks/useNotificationQueries';
+import type { AppNotification } from '../types';
+
+type NotificationListProps = {
+  query: NotificationsQueryResult;
+  viewerId: string;
+  onSelect(notification: AppNotification): void;
+};
+
+const MESSAGE_CLASS = 'py-10 text-center text-sm text-gray-500 dark:text-gray-400';
+
+/**
+ * 알림 목록.
+ *
+ * 로딩·오류·0건·무한스크롤을 다루는 방식은 받은 후기(ReviewList)·게시물 목록(PostList)과 같다.
+ */
+function NotificationList(props: NotificationListProps) {
+  const query = props.query;
+
+  const sentinelRef = useInfiniteScroll({
+    hasNextPage: query.hasNextPage,
+    isFetching: query.isFetchingNextPage,
+    onLoadMore: function loadMore(): void {
+      query.fetchNextPage();
+    },
+  });
+
+  // 항목마다 new Date()를 부르면 같은 목록에서 기준 시각이 어긋난다.
+  const now = new Date();
+
+  if (query.isLoading) {
+    return <p className={MESSAGE_CLASS}>알림을 불러오는 중입니다…</p>;
+  }
+
+  if (query.isError) {
+    return (
+      <p role="alert" className="py-10 text-center text-sm text-red-600 dark:text-red-400">
+        알림을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.
+      </p>
+    );
+  }
+
+  const notifications = (query.data?.pages ?? []).flat();
+
+  if (notifications.length === 0) {
+    return <p className={MESSAGE_CLASS}>아직 받은 알림이 없어요.</p>;
+  }
+
+  return (
+    <>
+      <ul className="flex flex-col divide-y divide-gray-100 dark:divide-gray-800">
+        {notifications.map(function renderNotification(notification: AppNotification) {
+          return (
+            <NotificationListItem
+              key={notification.id}
+              notification={notification}
+              viewerId={props.viewerId}
+              now={now}
+              onSelect={props.onSelect}
+            />
+          );
+        })}
+
+        {/* 다음 페이지를 부르는 표식. 목록의 일부가 아니라 관찰 대상일 뿐이다. */}
+        <li ref={sentinelRef} aria-hidden="true" className="h-px" />
+      </ul>
+
+      {query.isFetchingNextPage ? <p className={MESSAGE_CLASS}>더 불러오는 중입니다…</p> : null}
+    </>
+  );
+}
+
+export default NotificationList;

--- a/src/features/notification/components/notificationListItem.test.tsx
+++ b/src/features/notification/components/notificationListItem.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import NotificationListItem from './notificationListItem';
+import type { AppNotification, NotificationType } from '../types';
+
+const VIEWER_ID = 'viewer-1';
+const NOW = new Date('2026-08-05T00:10:00.000Z');
+
+function makeNotification(
+  overrides: Partial<AppNotification> & { type: NotificationType },
+): AppNotification {
+  return {
+    id: 1,
+    isRead: false,
+    createdAt: '2026-08-05T00:00:00.000Z',
+    actorId: 'actor-1',
+    actorNickname: '가지팔이',
+    actorAvatarUrl: null,
+    roomId: 9,
+    postId: null,
+    postTitle: null,
+    preview: null,
+    offerAmount: null,
+    ...overrides,
+  };
+}
+
+function renderItem(notification: AppNotification, onSelect = jest.fn()) {
+  render(
+    <MemoryRouter>
+      <ul>
+        <NotificationListItem
+          notification={notification}
+          viewerId={VIEWER_ID}
+          now={NOW}
+          onSelect={onSelect}
+        />
+      </ul>
+    </MemoryRouter>,
+  );
+
+  return onSelect;
+}
+
+describe('NotificationListItem', function notificationListItemSuite() {
+  it('알림을 누르면 읽음 처리를 맡기고 그 방으로 가는 링크가 된다', function selectCase() {
+    const onSelect = renderItem(
+      makeNotification({ type: 'chat', roomId: 9, preview: '아직 있나요?' }),
+    );
+
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/chats/9');
+
+    return userEvent.click(link).then(function assertSelected() {
+      expect(onSelect).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // 색만으로는 색을 구분하지 못하는 사람에게 아무것도 전해지지 않는다.
+  it('안 읽은 알림은 색 말고 글자로도 표시한다', function unreadCase() {
+    renderItem(makeNotification({ type: 'chat', isRead: false }));
+
+    expect(screen.getByText('안 읽음')).toBeInTheDocument();
+  });
+
+  it('읽은 알림에는 그 표시가 없다', function readCase() {
+    renderItem(makeNotification({ type: 'chat', isRead: true }));
+
+    expect(screen.queryByText('안 읽음')).not.toBeInTheDocument();
+  });
+
+  // 눌러도 아무 일이 없는 링크를 남겨 두면 "눌렀는데 왜 안 가지"가 된다.
+  it('가리키던 방이 사라졌으면 링크로 그리지 않는다', function missingTargetCase() {
+    renderItem(makeNotification({ type: 'chat', roomId: null }));
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.getByText('가지팔이님이 메시지를 보냈어요')).toBeInTheDocument();
+  });
+});

--- a/src/features/notification/components/notificationListItem.tsx
+++ b/src/features/notification/components/notificationListItem.tsx
@@ -1,0 +1,90 @@
+import type { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+import { formatTimeAgo } from '../../../shared/utils/formatTimeAgo';
+import ProfileAvatar from '../../profile/components/profileAvatar';
+import { toNotificationView } from '../utils/notificationText';
+import type { AppNotification } from '../types';
+
+type NotificationListItemProps = {
+  notification: AppNotification;
+  /** 받은 후기가 어느 프로필에 붙는지 정하는 데 쓴다(notificationText 참고). */
+  viewerId: string;
+  /** 목록 전체가 같은 기준으로 "n분 전"을 계산하도록 부모가 넘긴다. */
+  now: Date;
+  onSelect(notification: AppNotification): void;
+};
+
+const ROW_CLASS = 'flex w-full items-start gap-3 px-2 py-4 text-left';
+
+/**
+ * 알림 한 줄.
+ *
+ * 안 읽은 줄은 **배경과 점 둘 다**로 표시한다. 색만으로는 색을 구분하지 못하는 사람에게
+ * 아무것도 전해지지 않고, 점만으로는 목록을 훑을 때 눈에 띄지 않는다.
+ * 스크린리더에는 제목 앞의 "안 읽음" 글자가 대신 읽힌다.
+ *
+ * 갈 곳이 없는 알림(가리키던 방·글이 지워진 경우)은 링크가 아니라 그냥 줄로 그린다.
+ * 눌러도 아무 일이 없는 링크를 남겨 두면 "눌렀는데 왜 안 가지"가 된다.
+ */
+function NotificationListItem(props: NotificationListItemProps) {
+  const notification = props.notification;
+  const view = toNotificationView(notification, props.viewerId);
+
+  const unreadClass = notification.isRead ? '' : 'bg-emerald-50/60 dark:bg-emerald-950/30';
+
+  const content: ReactNode = (
+    <>
+      <ProfileAvatar
+        nickname={notification.actorNickname ?? ''}
+        avatarUrl={notification.actorAvatarUrl}
+        size="sm"
+      />
+
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <p className="text-sm text-gray-900 dark:text-gray-50">
+          {notification.isRead ? null : <span className="sr-only">안 읽음 </span>}
+          <span className={notification.isRead ? '' : 'font-semibold'}>{view.title}</span>
+        </p>
+
+        {view.body === null ? null : (
+          <p className="truncate text-sm text-gray-600 dark:text-gray-300">{view.body}</p>
+        )}
+
+        <span className="text-xs text-gray-500 dark:text-gray-400">
+          {formatTimeAgo(notification.createdAt, props.now)}
+        </span>
+      </div>
+
+      {notification.isRead ? null : (
+        <span
+          aria-hidden="true"
+          className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-emerald-500 dark:bg-emerald-400"
+        />
+      )}
+    </>
+  );
+
+  if (view.to === null) {
+    return (
+      <li className={`${ROW_CLASS} ${unreadClass}`}>
+        {content}
+      </li>
+    );
+  }
+
+  return (
+    <li className={unreadClass}>
+      <Link
+        to={view.to}
+        onClick={function select(): void {
+          props.onSelect(notification);
+        }}
+        className={`${ROW_CLASS} transition hover:bg-gray-50 dark:hover:bg-gray-900`}
+      >
+        {content}
+      </Link>
+    </li>
+  );
+}
+
+export default NotificationListItem;

--- a/src/features/notification/components/notificationPage.tsx
+++ b/src/features/notification/components/notificationPage.tsx
@@ -1,0 +1,81 @@
+import NotificationList from './notificationList';
+import PageSpinner from '../../../shared/ui/pageSpinner';
+import { selectAuthUser, useAuthStore } from '../../auth/store/authStore';
+import {
+  useMarkAllNotificationsReadMutation,
+  useMarkNotificationReadMutation,
+} from '../hooks/useNotificationMutations';
+import { useNotificationsQuery } from '../hooks/useNotificationQueries';
+import { useNotificationsRealtime } from '../hooks/useNotificationRealtime';
+import type { AppNotification } from '../types';
+
+/**
+ * 알림 목록 화면.
+ *
+ * 탭바 **안**에 둔다. 마이페이지 하위 목록 넷처럼 `← 어디로`를 붙이지 않은 이유는
+ * 돌아갈 곳이 하나로 정해지지 않아서다 — 홈 헤더의 종에서도 오고 마이페이지에서도 온다.
+ * 탭바가 떠 있으면 어디서 왔든 원하는 곳으로 갈 수 있다.
+ *
+ * 로그인 가드는 라우터의 RequireMember가 이미 걸었다.
+ */
+function NotificationPage() {
+  const user = useAuthStore(selectAuthUser);
+  const viewerId = user?.id ?? null;
+
+  const notificationsQuery = useNotificationsQuery(viewerId);
+  // 이 화면을 보는 동안 새 알림이 오면 목록이 따라 움직인다.
+  useNotificationsRealtime(viewerId);
+
+  const markReadMutation = useMarkNotificationReadMutation(viewerId);
+  const markAllReadMutation = useMarkAllNotificationsReadMutation(viewerId);
+
+  if (viewerId === null) {
+    return <PageSpinner message="알림을 불러오는 중입니다…" />;
+  }
+
+  const notifications = (notificationsQuery.data?.pages ?? []).flat();
+  const hasUnread = notifications.some(function isUnread(notification: AppNotification): boolean {
+    return !notification.isRead;
+  });
+
+  return (
+    <main className="mx-auto flex max-w-screen-sm flex-col gap-4 p-6">
+      <header className="flex items-center justify-between gap-3">
+        <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-50">알림</h1>
+
+        {/* 받아 온 페이지에 안 읽은 것이 없으면 감춘다. 서버는 안 읽은 것 전부를 읽음 처리하므로
+            아래쪽 페이지에 남아 있어도 이 버튼 한 번이면 함께 정리된다. */}
+        {hasUnread ? (
+          <button
+            type="button"
+            onClick={function markAll(): void {
+              markAllReadMutation.mutate();
+            }}
+            disabled={markAllReadMutation.isPending}
+            className="rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-medium
+                       text-gray-700 transition hover:bg-gray-50 disabled:opacity-50
+                       dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800"
+          >
+            {markAllReadMutation.isPending ? '처리 중…' : '모두 읽음'}
+          </button>
+        ) : null}
+      </header>
+
+      {markAllReadMutation.isError ? (
+        <p role="alert" className="text-sm text-red-600 dark:text-red-400">
+          읽음 표시에 실패했습니다. 잠시 후 다시 시도해 주세요.
+        </p>
+      ) : null}
+
+      <NotificationList
+        query={notificationsQuery}
+        viewerId={viewerId}
+        onSelect={function markOneRead(notification: AppNotification): void {
+          markReadMutation.mutate({ id: notification.id, wasRead: notification.isRead });
+        }}
+      />
+    </main>
+  );
+}
+
+export default NotificationPage;

--- a/src/features/notification/hooks/useNotificationMutations.ts
+++ b/src/features/notification/hooks/useNotificationMutations.ts
@@ -1,0 +1,79 @@
+import {
+  useMutation,
+  useQueryClient,
+  type InfiniteData,
+  type UseMutationResult,
+} from '@tanstack/react-query';
+import { notificationsQueryKey, unreadNotificationCountQueryKey } from './useNotificationQueries';
+import { markAllNotificationsRead, markNotificationRead } from '../api/notificationApi';
+import {
+  withAllNotificationsRead,
+  withDecrementedUnread,
+  withReadNotification,
+} from '../utils/notificationCache';
+import type { AppNotification } from '../types';
+
+/** useNotificationsQuery가 캐시에 넣는 모양. setQueryData에 그대로 넘긴다. */
+type NotificationCache = InfiniteData<AppNotification[]>;
+
+export type MarkNotificationReadInput = {
+  id: number;
+  /** 누를 때 이미 읽은 상태였는가. 배지를 두 번 깎지 않기 위해 필요하다. */
+  wasRead: boolean;
+};
+
+/**
+ * 알림 하나를 읽음으로.
+ *
+ * 캐시를 **보내기 전에** 고친다. 알림을 누르면 곧바로 화면이 넘어가므로 응답을 기다렸다
+ * 고치면 그 결과를 받을 화면이 이미 없다. 실패해도 되돌리지 않는다 — 잃는 것이 굵은 글씨
+ * 하나뿐이고, 다음 조회가 서버 값으로 덮는다.
+ */
+export function useMarkNotificationReadMutation(
+  viewerId: string | null,
+): UseMutationResult<void, Error, MarkNotificationReadInput> {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, Error, MarkNotificationReadInput>({
+    mutationFn: function markRead(input: MarkNotificationReadInput): Promise<void> {
+      return markNotificationRead(input.id);
+    },
+    onMutate: function updateCache(input: MarkNotificationReadInput): void {
+      queryClient.setQueryData<NotificationCache>(
+        notificationsQueryKey(viewerId),
+        function markOne(current) {
+          return withReadNotification(current, input.id);
+        },
+      );
+      queryClient.setQueryData<number>(
+        unreadNotificationCountQueryKey(viewerId),
+        function decrement(current) {
+          return withDecrementedUnread(current, input.wasRead);
+        },
+      );
+    },
+  });
+}
+
+/**
+ * 안 읽은 알림을 모두 읽음으로.
+ *
+ * 이쪽은 화면에 머무른 채 누르는 버튼이라 응답을 받고 나서 고친다.
+ * 실패하면 굵은 글씨가 그대로 남아 다시 누를 수 있다.
+ */
+export function useMarkAllNotificationsReadMutation(
+  viewerId: string | null,
+): UseMutationResult<void, Error, void> {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, Error, void>({
+    mutationFn: markAllNotificationsRead,
+    onSuccess: function updateCache(): void {
+      queryClient.setQueryData<NotificationCache>(
+        notificationsQueryKey(viewerId),
+        withAllNotificationsRead,
+      );
+      queryClient.setQueryData<number>(unreadNotificationCountQueryKey(viewerId), 0);
+    },
+  });
+}

--- a/src/features/notification/hooks/useNotificationQueries.ts
+++ b/src/features/notification/hooks/useNotificationQueries.ts
@@ -1,0 +1,66 @@
+import {
+  useInfiniteQuery,
+  useQuery,
+  type InfiniteData,
+  type UseInfiniteQueryResult,
+  type UseQueryResult,
+} from '@tanstack/react-query';
+import { fetchNotifications, fetchUnreadNotificationCount } from '../api/notificationApi';
+import { toNextNotificationCursor } from '../utils/notificationCursor';
+import type { AppNotification, NotificationCursor } from '../types';
+
+/**
+ * 알림은 Realtime이 새 것을 알려 주므로 시간으로 낡을 이유가 거의 없다.
+ * 그래도 0으로 두지는 않는다 — 목록과 배지를 오가며 매번 다시 부르게 된다.
+ */
+const NOTIFICATIONS_STALE_TIME_MS = 30_000;
+
+export type NotificationsQueryResult = UseInfiniteQueryResult<
+  InfiniteData<AppNotification[]>,
+  Error
+>;
+
+/**
+ * 알림은 전부 내 것이라 서버는 사용자 id를 받지 않는다. 그래도 키에는 넣는다 —
+ * 넣지 않으면 계정을 바꿔 들어왔을 때 앞사람의 알림이 그대로 남는다
+ * (pendingReviewsQueryKey와 같은 이유).
+ */
+export function notificationsQueryKey(userId: string | null): ReadonlyArray<string> {
+  return ['notifications', userId ?? 'anonymous'];
+}
+
+export function unreadNotificationCountQueryKey(userId: string | null): ReadonlyArray<string> {
+  return ['notifications', userId ?? 'anonymous', 'unreadCount'];
+}
+
+/** 내 알림 목록. 무한 스크롤이다. */
+export function useNotificationsQuery(userId: string | null): NotificationsQueryResult {
+  return useInfiniteQuery<AppNotification[], Error, InfiniteData<AppNotification[]>>({
+    queryKey: notificationsQueryKey(userId),
+    queryFn: function loadPage({ pageParam }): Promise<AppNotification[]> {
+      return fetchNotifications((pageParam as NotificationCursor | null) ?? null);
+    },
+    initialPageParam: null,
+    getNextPageParam: toNextNotificationCursor,
+    enabled: userId !== null,
+    staleTime: NOTIFICATIONS_STALE_TIME_MS,
+  });
+}
+
+/**
+ * 안 읽은 알림 수. 배지 하나를 위한 조회다.
+ *
+ * 목록 쿼리를 나눠 쓰지 않는다 — 목록은 무한 스크롤이라 첫 페이지만 받은 상태에서는
+ * 세어 봐야 20까지밖에 못 센다. 채팅 배지(useUnreadChatCount)가 목록을 그대로 합칠 수 있었던 것은
+ * 방 목록이 페이징 없이 통째로 오기 때문이다.
+ */
+export function useUnreadNotificationCountQuery(
+  userId: string | null,
+): UseQueryResult<number, Error> {
+  return useQuery<number, Error>({
+    queryKey: unreadNotificationCountQueryKey(userId),
+    queryFn: fetchUnreadNotificationCount,
+    enabled: userId !== null,
+    staleTime: NOTIFICATIONS_STALE_TIME_MS,
+  });
+}

--- a/src/features/notification/hooks/useNotificationRealtime.ts
+++ b/src/features/notification/hooks/useNotificationRealtime.ts
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { notificationsQueryKey } from './useNotificationQueries';
+import { subscribeToMyNotifications } from '../api/notificationApi';
+
+/**
+ * 새 알림이 들어오면 목록과 배지를 다시 읽게 한다.
+ *
+ * 채팅 메시지(`useChatRoomRealtime`)처럼 payload를 캐시에 직접 꽂지 않는다. Realtime이 주는 것은
+ * `notifications` 행 그대로 — id가 든 payload jsonb다. 목록이 쓰는 모양은 서버가 join해서 푼
+ * 것이라(0015) 둘이 다르고, 앞에서 풀어 준 값을 화면에서 다시 만들 방법이 없다.
+ *
+ * 그래서 "무언가 왔다"만 신호로 쓰고 다시 읽는다 — `useChatRoomsRealtime`이 방 목록에
+ * 한 것과 같은 판단이다.
+ */
+export function useNotificationsRealtime(viewerId: string | null): void {
+  const queryClient = useQueryClient();
+
+  useEffect(
+    function subscribeToNotifications(): (() => void) | undefined {
+      if (viewerId === null) {
+        return undefined;
+      }
+
+      return subscribeToMyNotifications(viewerId, function refresh(): void {
+        // 안 읽은 수의 키(`[…, 'unreadCount']`)가 목록 키로 시작하므로 이 한 번이 둘 다 낡게 한다.
+        // TanStack Query의 무효화는 앞부분이 같으면 걸린다.
+        queryClient.invalidateQueries({ queryKey: notificationsQueryKey(viewerId) });
+      });
+    },
+    [viewerId, queryClient],
+  );
+}

--- a/src/features/notification/types.ts
+++ b/src/features/notification/types.ts
@@ -1,0 +1,49 @@
+/**
+ * 알림 종류. 0001의 `notification_type` enum 그대로다.
+ *
+ * `comment`·`like`는 enum에만 있고 **이 값을 넣는 트리거가 아직 없다** — 댓글·찜 알림은
+ * 기능 자체가 없어서다. 그래도 타입에 남겨 둔다. 나중에 트리거만 더하면 화면이 그대로
+ * 받아 그리고, 빼 두면 그때 여기부터 다시 열어야 한다.
+ */
+export type NotificationType = 'comment' | 'like' | 'chat' | 'review' | 'price_offer';
+
+/**
+ * 알림 한 건. 0015의 `fetch_notifications`가 payload의 id를 풀어 준 뒤의 모양이다.
+ *
+ * 서버가 풀어 주는 이유는 성능이다 — 풀지 않으면 화면이 알림 한 줄마다 메시지·방·후기를
+ * 따로 조회하게 된다. 그래서 여기 있는 값은 대부분 **종류에 따라 비어 있을 수 있다**
+ * (후기 알림에 roomId가 없고, 채팅 알림에 offerAmount가 없다).
+ */
+export type AppNotification = {
+  id: number;
+  type: NotificationType;
+  isRead: boolean;
+  createdAt: string;
+  /** 알림을 일으킨 사람. 대상이 지워졌으면 null이다. */
+  actorId: string | null;
+  actorNickname: string | null;
+  actorAvatarUrl: string | null;
+  /** 채팅·가격제안이면 채워진다. 누르면 갈 방. */
+  roomId: number | null;
+  postId: number | null;
+  postTitle: string | null;
+  /** 메시지 내용 또는 후기 한 줄. 사진 메시지는 경로 대신 문구가 온다. */
+  preview: string | null;
+  offerAmount: number | null;
+};
+
+/** 알림 목록의 다음 페이지 시작점. 같은 시각 알림을 가르려고 id까지 들고 간다. */
+export type NotificationCursor = {
+  createdAt: string;
+  id: number;
+};
+
+/** 알림 한 줄을 화면에 그리기 위해 필요한 것 전부. notificationText가 만든다. */
+export type NotificationView = {
+  /** 굵게 뜨는 한 줄. "누가 무엇을 했다". */
+  title: string;
+  /** 그 아래 흐리게 뜨는 한 줄. 없으면 null. */
+  body: string | null;
+  /** 누르면 갈 곳. 갈 데가 없으면 null이고 그 줄은 누를 수 없다. */
+  to: string | null;
+};

--- a/src/features/notification/utils/notificationCache.test.ts
+++ b/src/features/notification/utils/notificationCache.test.ts
@@ -1,0 +1,85 @@
+import type { InfiniteData } from '@tanstack/react-query';
+import {
+  withAllNotificationsRead,
+  withDecrementedUnread,
+  withReadNotification,
+} from './notificationCache';
+import type { AppNotification } from '../types';
+
+function makeNotification(id: number, isRead: boolean): AppNotification {
+  return {
+    id,
+    type: 'chat',
+    isRead,
+    createdAt: '2026-08-05T00:00:00.000Z',
+    actorId: 'actor-1',
+    actorNickname: '가지팔이',
+    actorAvatarUrl: null,
+    roomId: 9,
+    postId: null,
+    postTitle: null,
+    preview: null,
+    offerAmount: null,
+  };
+}
+
+function makeCache(pages: AppNotification[][]): InfiniteData<AppNotification[]> {
+  return { pages, pageParams: pages.map(function toParam() {
+    return null;
+  }) };
+}
+
+describe('withReadNotification', function withReadNotificationSuite() {
+  it('해당 알림만 읽음으로 바꾼다', function marksOneCase() {
+    const cache = makeCache([[makeNotification(1, false), makeNotification(2, false)]]);
+
+    const next = withReadNotification(cache, 1);
+
+    expect(next?.pages[0][0].isRead).toBe(true);
+    expect(next?.pages[0][1].isRead).toBe(false);
+  });
+
+  // 두 번째 페이지까지 내려간 뒤 그 줄을 눌러도 굵은 글씨가 지워져야 한다.
+  it('나중에 받은 페이지에 있어도 찾아서 바꾼다', function laterPageCase() {
+    const cache = makeCache([[makeNotification(1, false)], [makeNotification(2, false)]]);
+
+    const next = withReadNotification(cache, 2);
+
+    expect(next?.pages[1][0].isRead).toBe(true);
+  });
+
+  it('아직 아무 페이지도 없으면 아무것도 하지 않는다', function emptyCase() {
+    expect(withReadNotification(undefined, 1)).toBeUndefined();
+  });
+});
+
+describe('withAllNotificationsRead', function withAllNotificationsReadSuite() {
+  it('받아 온 페이지 전부를 읽음으로 바꾼다', function marksAllCase() {
+    const cache = makeCache([[makeNotification(1, false)], [makeNotification(2, false)]]);
+
+    const next = withAllNotificationsRead(cache);
+
+    expect(next?.pages.flat().every(function isRead(n: AppNotification) {
+      return n.isRead;
+    })).toBe(true);
+  });
+});
+
+describe('withDecrementedUnread', function withDecrementedUnreadSuite() {
+  it('안 읽은 알림을 누르면 하나 줄어든다', function decrementCase() {
+    expect(withDecrementedUnread(3, false)).toBe(2);
+  });
+
+  // 이미 읽은 줄을 다시 눌러 배지가 깎이면 목록과 숫자가 어긋난다.
+  it('이미 읽은 알림을 다시 눌러도 줄지 않는다', function alreadyReadCase() {
+    expect(withDecrementedUnread(3, true)).toBe(3);
+  });
+
+  it('0 아래로는 내려가지 않는다', function floorCase() {
+    expect(withDecrementedUnread(0, false)).toBe(0);
+  });
+
+  it('아직 숫자를 받지 못했으면 0으로 둔다', function undefinedCase() {
+    expect(withDecrementedUnread(undefined, false)).toBe(0);
+  });
+});

--- a/src/features/notification/utils/notificationCache.ts
+++ b/src/features/notification/utils/notificationCache.ts
@@ -1,0 +1,61 @@
+import type { InfiniteData } from '@tanstack/react-query';
+import type { AppNotification } from '../types';
+
+/**
+ * 읽음 표시를 캐시에 그 자리에서 반영한다.
+ *
+ * 무효화하고 다시 읽지 않는 이유: 알림을 누르면 곧바로 다른 화면으로 넘어간다. 그 순간
+ * 목록을 다시 부르면 이미 떠난 화면을 위한 요청이 되고, 돌아왔을 때는 어차피 stale time이
+ * 지나 다시 읽는다. 굵은 글씨 하나 지우자고 왕복할 이유가 없다.
+ *
+ * 모르는 id면 아무것도 하지 않는다 — 아직 안 받아 온 페이지의 것이다.
+ */
+export function withReadNotification(
+  data: InfiniteData<AppNotification[]> | undefined,
+  notificationId: number,
+): InfiniteData<AppNotification[]> | undefined {
+  if (data === undefined) {
+    return data;
+  }
+
+  return {
+    ...data,
+    pages: data.pages.map(function markInPage(page: AppNotification[]): AppNotification[] {
+      return page.map(function markOne(current: AppNotification): AppNotification {
+        return current.id === notificationId ? { ...current, isRead: true } : current;
+      });
+    }),
+  };
+}
+
+/** "모두 읽음"이 누른 뒤의 목록. 받아 온 페이지 전부가 읽은 상태가 된다. */
+export function withAllNotificationsRead(
+  data: InfiniteData<AppNotification[]> | undefined,
+): InfiniteData<AppNotification[]> | undefined {
+  if (data === undefined) {
+    return data;
+  }
+
+  return {
+    ...data,
+    pages: data.pages.map(function markPage(page: AppNotification[]): AppNotification[] {
+      return page.map(function markOne(current: AppNotification): AppNotification {
+        return current.isRead ? current : { ...current, isRead: true };
+      });
+    }),
+  };
+}
+
+/**
+ * 배지 숫자를 하나 줄인다.
+ *
+ * 이미 읽은 알림을 다시 누르면 줄이지 않는다 — 화면이 그 판단을 하도록 두면 "누를 때마다
+ * 하나씩"이라는 규칙이 두 곳에 흩어진다. 0 아래로는 내려가지 않는다.
+ */
+export function withDecrementedUnread(count: number | undefined, wasRead: boolean): number {
+  if (count === undefined || wasRead) {
+    return Math.max(count ?? 0, 0);
+  }
+
+  return Math.max(count - 1, 0);
+}

--- a/src/features/notification/utils/notificationCursor.test.ts
+++ b/src/features/notification/utils/notificationCursor.test.ts
@@ -1,0 +1,51 @@
+import { toNextNotificationCursor } from './notificationCursor';
+import { NOTIFICATIONS_PAGE_SIZE } from '../api/notificationApi';
+import type { AppNotification } from '../types';
+
+jest.mock('../api/notificationApi', function mockNotificationApi() {
+  // notificationApi는 supabaseClient를 거쳐 import.meta.env에 닿는다. ts-jest가 CommonJS로
+  // 옮기면서 import.meta를 그대로 뱉으므로 실제 모듈은 로드하지 않는다(troble.md 「탐색」 1번).
+  // 커서 유틸이 페이지 크기 상수 하나 때문에 API를 import하는 구조를 그대로 따랐으므로
+  // 그 처방도 함께 따라온다.
+  return { NOTIFICATIONS_PAGE_SIZE: 20 };
+});
+
+function makeNotification(id: number): AppNotification {
+  return {
+    id,
+    type: 'chat',
+    isRead: false,
+    createdAt: `2026-08-0${(id % 9) + 1}T00:00:00.000Z`,
+    actorId: 'actor-1',
+    actorNickname: '가지팔이',
+    actorAvatarUrl: null,
+    roomId: 9,
+    postId: null,
+    postTitle: null,
+    preview: null,
+    offerAmount: null,
+  };
+}
+
+function makeFullPage(): AppNotification[] {
+  return Array.from({ length: NOTIFICATIONS_PAGE_SIZE }, function toNotification(_, index: number) {
+    return makeNotification(index + 1);
+  });
+}
+
+describe('toNextNotificationCursor', function notificationCursorSuite() {
+  it('페이지가 다 찼으면 마지막 알림을 커서로 준다', function fullPageCase() {
+    const page = makeFullPage();
+    const last = page[page.length - 1];
+
+    expect(toNextNotificationCursor(page)).toEqual({ createdAt: last.createdAt, id: last.id });
+  });
+
+  it('페이지가 덜 찼으면 다음이 없다', function partialPageCase() {
+    expect(toNextNotificationCursor([makeNotification(1)])).toBeUndefined();
+  });
+
+  it('빈 페이지도 다음이 없다', function emptyPageCase() {
+    expect(toNextNotificationCursor([])).toBeUndefined();
+  });
+});

--- a/src/features/notification/utils/notificationCursor.ts
+++ b/src/features/notification/utils/notificationCursor.ts
@@ -1,0 +1,22 @@
+import { NOTIFICATIONS_PAGE_SIZE } from '../api/notificationApi';
+import type { AppNotification, NotificationCursor } from '../types';
+
+/**
+ * 방금 받은 페이지를 보고 다음 커서를 정한다.
+ *
+ * 규칙은 받은 후기(review/utils/reviewCursor)와 같다 — 한 페이지가 다 차지 않았으면
+ * 뒤에 남은 것이 없다는 뜻이다. 딱 떨어질 때 한 번 헛걸음하는 것도 그대로다.
+ *
+ * TanStack Query의 getNextPageParam은 undefined를 "다음 없음"으로 읽는다.
+ */
+export function toNextNotificationCursor(
+  lastPage: AppNotification[],
+): NotificationCursor | undefined {
+  if (lastPage.length < NOTIFICATIONS_PAGE_SIZE) {
+    return undefined;
+  }
+
+  const lastNotification = lastPage[lastPage.length - 1];
+
+  return { createdAt: lastNotification.createdAt, id: lastNotification.id };
+}

--- a/src/features/notification/utils/notificationText.test.ts
+++ b/src/features/notification/utils/notificationText.test.ts
@@ -1,0 +1,115 @@
+import { toNotificationView } from './notificationText';
+import type { AppNotification, NotificationType } from '../types';
+
+const VIEWER_ID = 'viewer-1';
+
+function makeNotification(overrides: Partial<AppNotification> & { type: NotificationType }): AppNotification {
+  return {
+    id: 1,
+    isRead: false,
+    createdAt: '2026-08-05T00:00:00.000Z',
+    actorId: 'actor-1',
+    actorNickname: '가지팔이',
+    actorAvatarUrl: null,
+    roomId: null,
+    postId: null,
+    postTitle: null,
+    preview: null,
+    offerAmount: null,
+    ...overrides,
+  };
+}
+
+describe('toNotificationView', function notificationTextSuite() {
+  it('채팅 알림은 보낸 사람과 내용을 보여주고 그 방으로 보낸다', function chatCase() {
+    const view = toNotificationView(
+      makeNotification({ type: 'chat', roomId: 9, preview: '아직 있나요?' }),
+      VIEWER_ID,
+    );
+
+    expect(view.title).toBe('가지팔이님이 메시지를 보냈어요');
+    expect(view.body).toBe('아직 있나요?');
+    expect(view.to).toBe('/chats/9');
+  });
+
+  // 금액이 제목에 있어야 알림만 보고도 판단이 선다. 열어 봐야 아는 알림은 알림이 아니다.
+  it('가격 제안 알림은 금액을 제목에 적는다', function priceOfferCase() {
+    const view = toNotificationView(
+      makeNotification({
+        type: 'price_offer',
+        roomId: 9,
+        offerAmount: 35000,
+        postTitle: '아이패드',
+      }),
+      VIEWER_ID,
+    );
+
+    expect(view.title).toBe('가지팔이님이 35,000원을 제안했어요');
+    expect(view.body).toBe('아이패드');
+    expect(view.to).toBe('/chats/9');
+  });
+
+  it('금액을 알 수 없는 가격 제안도 문장이 깨지지 않는다', function priceOfferWithoutAmountCase() {
+    const view = toNotificationView(
+      makeNotification({ type: 'price_offer', roomId: 9 }),
+      VIEWER_ID,
+    );
+
+    expect(view.title).toBe('가지팔이님이 가격을 제안했어요');
+  });
+
+  // 받은 후기는 내 프로필에 쌓인다. 후기 한 건만 여는 화면이 없어서 viewerId가 필요하다.
+  it('후기 알림은 내 프로필로 보낸다', function reviewCase() {
+    const view = toNotificationView(
+      makeNotification({ type: 'review', postId: 7, postTitle: '아이패드', preview: '친절해요' }),
+      VIEWER_ID,
+    );
+
+    expect(view.title).toBe('가지팔이님이 거래후기를 남겼어요');
+    expect(view.body).toBe('친절해요');
+    expect(view.to).toBe(`/users/${VIEWER_ID}`);
+  });
+
+  it('한 줄 후기가 없으면 어떤 거래였는지를 대신 보여준다', function reviewWithoutCommentCase() {
+    const view = toNotificationView(
+      makeNotification({ type: 'review', postId: 7, postTitle: '아이패드' }),
+      VIEWER_ID,
+    );
+
+    expect(view.body).toBe('아이패드');
+  });
+
+  // 아직 이 값을 넣는 트리거가 없지만 enum에는 있다. 닿았을 때 빈 줄이 되면 안 된다.
+  it('댓글·찜 알림은 트리거가 생기기 전에도 게시물로 보낸다', function commentAndLikeCase() {
+    const comment = toNotificationView(
+      makeNotification({ type: 'comment', postId: 7, preview: '아직 있나요?' }),
+      VIEWER_ID,
+    );
+    const like = toNotificationView(
+      makeNotification({ type: 'like', postId: 7, postTitle: '아이패드' }),
+      VIEWER_ID,
+    );
+
+    expect(comment.title).toBe('가지팔이님이 댓글을 남겼어요');
+    expect(comment.to).toBe('/posts/7');
+    expect(like.title).toBe('가지팔이님이 관심을 표시했어요');
+    expect(like.to).toBe('/posts/7');
+  });
+
+  // 프로필은 cascade로 사라져도 알림 행은 남는다. "님이 메시지를 보냈어요"가 되면 안 된다.
+  it('보낸 사람이 사라졌어도 문장이 완성된다', function missingActorCase() {
+    const view = toNotificationView(
+      makeNotification({ type: 'chat', roomId: 9, actorId: null, actorNickname: null }),
+      VIEWER_ID,
+    );
+
+    expect(view.title).toBe('알 수 없는 이웃님이 메시지를 보냈어요');
+  });
+
+  // 눌러도 아무 일이 없는 링크를 남겨 두면 "눌렀는데 왜 안 가지"가 된다.
+  it('가리키던 방이 사라졌으면 갈 곳을 주지 않는다', function missingTargetCase() {
+    const view = toNotificationView(makeNotification({ type: 'chat', roomId: null }), VIEWER_ID);
+
+    expect(view.to).toBeNull();
+  });
+});

--- a/src/features/notification/utils/notificationText.ts
+++ b/src/features/notification/utils/notificationText.ts
@@ -1,0 +1,86 @@
+import { formatPrice } from '../../../shared/utils/formatPrice';
+import type { AppNotification, NotificationView } from '../types';
+
+/**
+ * 알림을 일으킨 사람이 지워졌을 때 쓰는 이름.
+ *
+ * 알림 행은 남고(payload에 id만 있다) 프로필은 cascade로 사라질 수 있다. "님이"로 이어지는
+ * 문장이라 빈 문자열을 넣으면 "님이 메시지를 보냈어요"가 된다.
+ */
+const UNKNOWN_ACTOR = '알 수 없는 이웃';
+
+function toActorName(notification: AppNotification): string {
+  return notification.actorNickname ?? UNKNOWN_ACTOR;
+}
+
+/** 채팅 알림이 가리키는 방. 방이 지워졌으면 갈 곳이 없다. */
+function toRoomPath(notification: AppNotification): string | null {
+  return notification.roomId === null ? null : `/chats/${notification.roomId}`;
+}
+
+function toPostPath(notification: AppNotification): string | null {
+  return notification.postId === null ? null : `/posts/${notification.postId}`;
+}
+
+/**
+ * 알림 한 건을 화면에 그릴 문구와 이동 경로로 바꾼다.
+ *
+ * 순수 함수인 이유는 테스트만이 아니다. 알림은 종류마다 문장이 다르고 갈 곳도 다른데,
+ * 그 분기를 컴포넌트 안에 두면 "어떤 알림이 어디로 가는가"를 확인하려고 화면을 그려야 한다.
+ * payload를 푸는 일은 서버(0015)가 하고, 그것을 사람의 말로 바꾸는 일은 여기서 한다.
+ *
+ * `viewerId`를 받는 이유는 후기 하나 때문이다 — 받은 후기는 **내 프로필**에 붙으므로
+ * 알림 행만 봐서는 갈 곳을 알 수 없다.
+ *
+ * `comment`·`like`는 아직 이 값을 넣는 트리거가 없어 실제로는 오지 않는다. 그래도 다뤄 둔다 —
+ * enum에 있는 값이 화면에 닿았을 때 빈 줄이 되는 것보다는 낫고, 나중에 트리거만 더하면 된다.
+ */
+export function toNotificationView(
+  notification: AppNotification,
+  viewerId: string,
+): NotificationView {
+  const actor = toActorName(notification);
+
+  switch (notification.type) {
+    case 'chat':
+      return {
+        title: `${actor}님이 메시지를 보냈어요`,
+        body: notification.preview,
+        to: toRoomPath(notification),
+      };
+
+    case 'price_offer':
+      return {
+        title:
+          notification.offerAmount === null
+            ? `${actor}님이 가격을 제안했어요`
+            : `${actor}님이 ${formatPrice(notification.offerAmount)}을 제안했어요`,
+        // 금액이 제목에 있으므로 아래는 "무엇에 대한 제안인가"를 맡는다.
+        body: notification.postTitle,
+        to: toRoomPath(notification),
+      };
+
+    case 'review':
+      return {
+        title: `${actor}님이 거래후기를 남겼어요`,
+        // 한 줄 후기는 선택이라 없을 수 있다. 그때는 어떤 거래였는지라도 보인다.
+        body: notification.preview ?? notification.postTitle,
+        // 받은 후기는 내 프로필에 쌓인다. 후기 한 건만 여는 화면은 없다.
+        to: `/users/${viewerId}`,
+      };
+
+    case 'comment':
+      return {
+        title: `${actor}님이 댓글을 남겼어요`,
+        body: notification.preview ?? notification.postTitle,
+        to: toPostPath(notification),
+      };
+
+    case 'like':
+      return {
+        title: `${actor}님이 관심을 표시했어요`,
+        body: notification.postTitle,
+        to: toPostPath(notification),
+      };
+  }
+}

--- a/src/features/profile/components/myPageMenu.tsx
+++ b/src/features/profile/components/myPageMenu.tsx
@@ -9,8 +9,13 @@ type MyPageMenuItem = {
 /**
  * 마이페이지에서 갈 수 있는 곳. 순서는 자주 여는 것부터다.
  * 차단 목록은 맨 아래다 — 거래하다 한 번 들를까 말까 한 관리 화면이다.
+ *
+ * 알림에는 안 읽은 배지를 달지 않는다. 배지는 홈 헤더의 종 하나뿐이다 —
+ * 같은 숫자를 두 곳에 그리면 한쪽만 늦게 갱신될 때 어느 쪽이 맞는지 알 수 없다.
+ * 여기 링크는 홈까지 돌아가지 않아도 되는 두 번째 길일 뿐이다.
  */
 const MENU_ITEMS: ReadonlyArray<MyPageMenuItem> = [
+  { to: '/notifications', icon: '🔔', label: '알림' },
   { to: '/my/likes', icon: '♡', label: '관심목록' },
   { to: '/my/recent', icon: '🕘', label: '최근 본 글' },
   { to: '/my/purchases', icon: '🧾', label: '구매내역' },

--- a/supabase/migrations/0015_notification.sql
+++ b/supabase/migrations/0015_notification.sql
@@ -1,0 +1,238 @@
+-- =============================================================================
+-- 알림
+--
+-- 0001부터 `notifications` 테이블과 정책이 있었고, 트리거 둘(`on_message_insert`,
+-- `recalc_manner_temp`)이 **이미 행을 쌓고 있었다.** 없던 것은 읽는 쪽이다 —
+-- 채팅·가격제안·후기 알림이 쌓이기만 하고 아무도 보지 않았다.
+--
+-- 그래서 이 파일은 새 알림을 만드는 일이 아니라 **쌓인 것을 꺼내 쓸 수 있게 하는 일**이다.
+--   1. Realtime publication에 notifications를 넣는다 (0008이 messages·chat_rooms만 넣었다)
+--   2. update에서 is_read 말고는 못 바꾸게 막는다 (messages의 guard_message_update와 같은 자리)
+--   3. payload의 id를 풀어 화면이 바로 그릴 수 있는 모양으로 내려주는 fetch_notifications
+--   4. 안 읽은 수 count_unread_notifications
+--   5. 차단하면 그 사람에게서 온 알림도 함께 지운다
+--
+-- `notification_type` enum에는 `comment`·`like`도 있지만 **이 값을 넣는 트리거는 아직 없다.**
+-- 댓글·찜은 아직 기능 자체가 없어서다. 아래 3번은 두 타입도 함께 풀어 두었다 —
+-- 나중에 트리거만 더하면 화면은 그대로 굴러간다.
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- 1. Realtime
+--
+-- 0008이 `supabase_realtime`에 messages·chat_rooms를 넣었지만 notifications는 빠져 있었다.
+-- 넣지 않으면 구독은 조용히 성공하고 이벤트만 영원히 오지 않는다 — 실패로 보이지 않아
+-- 더 찾기 어려운 종류의 누락이다.
+--
+-- `replica identity full`은 걸지 않는다. 그것이 필요한 것은 update의 **이전 행**을 볼 때인데
+-- (messages의 읽음 표시가 그랬다), 알림은 insert만 구독한다. 읽음 표시는 누른 본인의 화면에서
+-- 일어나므로 캐시를 그 자리에서 고치면 되고 서버가 되돌려 줄 이유가 없다.
+-- -----------------------------------------------------------------------------
+do $$
+begin
+  if not exists (
+    select 1 from pg_publication_tables
+     where pubname = 'supabase_realtime' and schemaname = 'public' and tablename = 'notifications'
+  ) then
+    alter publication supabase_realtime add table notifications;
+  end if;
+end;
+$$;
+
+-- -----------------------------------------------------------------------------
+-- 2. update는 읽음 표시만
+--
+-- 0001의 `notifications_update`는 `auth.uid() = user_id` 하나뿐이다. 내 알림이면 **무엇이든**
+-- 바꿀 수 있다는 뜻이라, 마음먹으면 남이 보낸 알림의 문구 근거가 되는 payload를 바꿔치기할 수 있다.
+--
+-- messages에 `guard_message_update`(0008)를 둔 것과 같은 이유로 여기도 컬럼을 잠근다.
+-- 화면이 보내는 update는 `is_read` 하나뿐이므로 잃는 것이 없다.
+-- -----------------------------------------------------------------------------
+create or replace function guard_notification_update()
+returns trigger
+language plpgsql
+as $$
+begin
+  if new.user_id    is distinct from old.user_id
+  or new.type       is distinct from old.type
+  or new.payload    is distinct from old.payload
+  or new.created_at is distinct from old.created_at then
+    raise exception '알림은 읽음 표시만 바꿀 수 있습니다.'
+      using errcode = 'check_violation';
+  end if;
+
+  return new;
+end;
+$$;
+
+comment on function guard_notification_update is
+  '알림 update에서 is_read 외의 컬럼 변경을 막는다. 알림이 가리키는 대상이 사후에 바뀌지 않게 하는 자리.';
+
+drop trigger if exists notifications_guard_update on notifications;
+create trigger notifications_guard_update
+  before update on notifications
+  for each row execute function guard_notification_update();
+
+-- -----------------------------------------------------------------------------
+-- 3. 알림 목록 — payload를 화면이 쓸 모양으로 푼다
+--
+-- payload에 들어 있는 것은 id뿐이다.
+--
+--   chat · price_offer : {"room_id": 12, "message_id": 340}
+--   review             : {"post_id": 7, "review_id": 3}
+--
+-- 이대로 내려보내면 화면이 알림 한 줄마다 메시지·방·후기·프로필을 따로 조회하게 된다.
+-- 스무 줄이면 조회 수십 번이다. 그래서 서버가 한 번에 풀어서 준다 — 0009의 마이페이지 목록,
+-- 0013의 `fetch_user_reviews`가 제목·닉네임을 함께 내려준 것과 같은 판단이다.
+--
+-- `security invoker`(기본)로 둔다. join하는 messages·chat_rooms에 각자의 select 정책이
+-- 그대로 걸리는데, 알림을 받은 사람은 그 방의 참여자이므로 통과한다. definer로 올려서
+-- 정책을 우회할 이유가 없고, 우회하지 않는 편이 안전하다.
+--
+-- 커서는 `(created_at, id)`다. 같은 초에 알림이 둘 이상 들어올 수 있어(메시지 연달아 보내기)
+-- created_at만으로는 페이지 경계에서 행이 새거나 겹친다 — 0013과 같은 이유, 같은 모양.
+-- -----------------------------------------------------------------------------
+create or replace function fetch_notifications(
+  p_cursor_at timestamptz default null,
+  p_cursor_id bigint      default null,
+  p_limit     integer     default 20
+)
+returns table (
+  id               bigint,
+  type             notification_type,
+  is_read          boolean,
+  created_at       timestamptz,
+  actor_id         uuid,
+  actor_nickname   text,
+  actor_avatar_url text,
+  room_id          bigint,
+  post_id          bigint,
+  post_title       text,
+  preview          text,
+  offer_amount     integer
+)
+language sql
+stable
+as $$
+  select n.id,
+         n.type,
+         n.is_read,
+         n.created_at,
+         actor.id,
+         actor.nickname,
+         actor.avatar_url,
+         m.room_id,
+         p.id,
+         p.title,
+         -- 미리보기. 사진은 경로가 들어 있으므로(0008) 그대로 보이면 안 된다.
+         case
+           when m.id is not null then
+             case when m.type = 'image' then '사진을 보냈어요' else m.content end
+           when rv.id is not null then rv.comment
+           else null
+         end,
+         m.offer_amount
+    from notifications n
+    -- payload에 그 키가 없으면 ->> 가 null을 주고 join이 비어 남는다. 타입별 분기가 따로 필요 없다.
+    left join messages   m     on m.id  = (n.payload ->> 'message_id')::bigint
+    left join chat_rooms cr    on cr.id = m.room_id
+    left join reviews    rv    on rv.id = (n.payload ->> 'review_id')::bigint
+    -- 게시물은 세 갈래로 온다: 채팅이면 방이 물고 있고, 후기면 후기가 물고 있고,
+    -- 댓글·찜(아직 트리거 없음)이면 payload에 직접 들어올 것이다.
+    left join posts      p     on p.id  = coalesce(cr.post_id, rv.post_id,
+                                                   (n.payload ->> 'post_id')::bigint)
+    left join profiles   actor on actor.id = coalesce(m.sender_id, rv.reviewer_id)
+   where n.user_id = auth.uid()
+     and (
+       p_cursor_at is null
+       or n.created_at < p_cursor_at
+       or (n.created_at = p_cursor_at and n.id < coalesce(p_cursor_id, 0))
+     )
+   order by n.created_at desc, n.id desc
+   limit least(greatest(coalesce(p_limit, 20), 1), 50);
+$$;
+
+comment on function fetch_notifications(timestamptz, bigint, integer) is
+  '내 알림 목록. payload의 id를 풀어 상대·게시물·미리보기까지 함께 주고 (created_at, id) keyset 페이징한다.';
+
+-- -----------------------------------------------------------------------------
+-- 4. 안 읽은 수
+--
+-- 배지 하나를 위해 목록 전체를 받아 세지 않는다. 채팅 배지가 `fetch_chat_rooms`를 그대로
+-- 나눠 쓴 것(useUnreadChatCount)과 다른 선택인데, 그쪽은 배지와 **목록 화면이 같은 쿼리**라
+-- 캐시를 나눠 쓰는 이득이 있었다. 알림은 배지가 홈 헤더에, 목록은 다른 화면에 있고
+-- 목록은 무한 스크롤이라 "전부 받아서 세기"가 애초에 불가능하다.
+-- -----------------------------------------------------------------------------
+create or replace function count_unread_notifications()
+returns integer
+language sql
+stable
+as $$
+  select count(*)::integer
+    from notifications
+   where user_id = auth.uid()
+     and is_read = false;
+$$;
+
+comment on function count_unread_notifications() is
+  '내 안 읽은 알림 수. 홈 헤더 배지가 쓴다.';
+
+-- 위 count 전용. 0001의 notifications_user_idx는 (user_id, created_at desc)라 3번의
+-- 정렬은 덮지만 "안 읽은 것만"은 걸러 낸 뒤에야 세게 된다. 부분 인덱스가 훨씬 작다
+-- (읽은 알림이 대부분을 차지하므로 — messages_unread_idx가 0008에서 같은 이유로 생겼다).
+create index if not exists notifications_unread_idx
+  on notifications (user_id)
+  where is_read = false;
+
+-- -----------------------------------------------------------------------------
+-- 5. 차단하면 그 사람에게서 온 알림도 지운다
+--
+-- 0014는 차단을 "안 보이게 하는 것"으로 정하고 목록 넷에서 걸러 냈다. 알림도 같은 대상인데,
+-- 여기서는 **거르는 것만으로 부족하다** — 목록에서만 빼면 배지는 3을 가리키는데 열어 보면
+-- 한 줄뿐인 화면이 된다. 배지는 4번처럼 단순히 세야 값이 싸고, 목록은 걸러야 하니
+-- 둘이 어긋난다.
+--
+-- 그래서 목록에 필터를 다는 대신 **차단하는 순간 지운다.** 차단당한 쪽의 알림도 함께 지운다 —
+-- 0014의 `fetch_chat_rooms`가 양방향으로 방을 감추므로, 한쪽에만 알림이 남으면 눌러도
+-- 갈 곳이 없는 알림이 된다.
+--
+-- 해제해도 지난 알림은 돌아오지 않는다. 알림은 원래 "그때 알려 주는 것"이라 되돌릴 값이 아니고,
+-- 방과 대화는 0014대로 그대로 돌아온다.
+--
+-- `security definer`인 이유: notifications에는 delete 정책이 아예 없다(0001). 본인 알림을
+-- 지우는 길을 클라이언트에 열어 줄 생각이 없어서 정책을 더하지 않고 이 트리거 안에서만 지운다.
+-- -----------------------------------------------------------------------------
+create or replace function purge_blocked_notifications()
+returns trigger
+language plpgsql
+security definer set search_path = public
+as $$
+begin
+  delete from notifications n
+   where n.user_id in (new.blocker_id, new.blocked_id)
+     and (
+       exists (
+         select 1 from messages m
+          where m.id = (n.payload ->> 'message_id')::bigint
+            and m.sender_id in (new.blocker_id, new.blocked_id)
+            and m.sender_id <> n.user_id
+       )
+       or exists (
+         select 1 from reviews r
+          where r.id = (n.payload ->> 'review_id')::bigint
+            and r.reviewer_id in (new.blocker_id, new.blocked_id)
+            and r.reviewer_id <> n.user_id
+       )
+     );
+
+  return new;
+end;
+$$;
+
+comment on function purge_blocked_notifications is
+  '차단이 생기면 두 사람 사이에서 오간 알림을 양쪽에서 지운다. 목록만 걸러 내면 배지 숫자와 어긋난다.';
+
+drop trigger if exists blocks_after_insert on blocks;
+create trigger blocks_after_insert
+  after insert on blocks
+  for each row execute function purge_blocked_notifications();

--- a/todo.md
+++ b/todo.md
@@ -149,17 +149,25 @@
   (0013이 `reviews`에 그랬던 것과 같은 이유), `insert ... returning`이 select 정책 없는 테이블에서
   막히는 바람에 `create_report`가 `returns void`가 됐다(troble.md 같은 절 1번).
 
-## 7단계 — 알림
+## 7단계 — 알림 ✅ 완료 (2026-08-05)
+
+구현 노트는 `note.md`의 "알림", 막혔던 부분은 `troble.md`의 같은 절에 있다.
 
 - **현황**: `notifications` 테이블에 **트리거가 이미 행을 쌓고 있는데** 읽는 화면이 없어 채팅·후기
-  알림이 그대로 버려지는 중이다. `on_message_insert`(chat/price_offer)와
+  알림이 그대로 버려지는 중이었다. `on_message_insert`(chat/price_offer)와
   `recalc_manner_temp`(review)가 넣고 있다.
-- **설계**: `/notifications` + 탭바(또는 헤더)에 안 읽은 배지. Realtime 구독은
-  `useChatRealtime.ts` 패턴을 그대로 따른다. `payload jsonb`를 타입별로 해석해 문구와 이동 경로를
-  만드는 순수 함수(`notificationText.ts`)를 두고 단위 테스트한다.
+- **한 것**: `/notifications`(탭바 안) + 홈 헤더의 종에 안 읽은 배지. 배지는 한 곳뿐이다 —
+  마이페이지 메뉴에도 링크를 뒀지만 숫자는 없다. `payload jsonb`는 **서버가 푼다**
+  (`fetch_notifications`가 join 다섯으로 닉네임·게시물 제목·미리보기까지 준다) — 풀지 않으면
+  화면이 알림 한 줄마다 따로 조회하게 된다. 그것을 사람의 말과 이동 경로로 바꾸는 자리만
+  순수 함수(`notificationText.ts`)로 두고 단위 테스트했다.
 - **주의**: `notification_type` enum에 `comment`·`like`가 있지만 **이 값을 넣는 트리거가 없다.**
-  댓글·찜 알림까지 원하면 트리거를 새로 만들어야 한다(프론트 작업만으로는 안 된다).
-- **마이그레이션**: 댓글·찜 알림을 넣을 때만 필요
+  `notificationText`는 두 타입을 이미 다루므로 트리거만 더하면 화면은 그대로 굴러간다.
+- **마이그레이션**: `0015_notification.sql` — "댓글·찜 알림을 넣을 때만 필요"로 적어 뒀지만
+  손댈 곳이 넷이었다. Realtime publication에 `notifications`가 아예 없었고(구독이 조용히
+  성공하고 이벤트만 안 온다), `notifications_update`가 payload까지 바꿀 수 있었고,
+  목록을 화면이 쓸 모양으로 푸는 RPC가 필요했고, **6단계가 알림에 남긴 구멍**을 메워야 했다
+  (차단해도 그 사람의 알림이 그대로 남는다 — troble.md 같은 절 1번).
 
 ## 8단계 — 계정
 

--- a/troble.md
+++ b/troble.md
@@ -1279,3 +1279,142 @@ const post = props.post ?? null;
 
 **교훈**: props의 필드를 조건부로 쓸 때는 **먼저 지역 상수로 꺼낸다.** `?.`를 덧붙여
 컴파일러를 달래는 순간, 타입 오류가 알려 주려던 "정말 없을 때 무슨 값이 나가는가"를 놓친다.
+
+---
+
+## 알림 (2026-08-05)
+
+### 1. 배지는 3인데 목록에는 한 줄 — 차단이 남긴 구멍
+
+**증상**: 코드를 쓰기 전에 설계 단계에서 먼저 걸린 문제다.
+
+6단계(차단)는 차단을 "안 보이게 하는 것"으로 정하고 목록 넷에서 걸러 냈다. 알림도 같은 대상이다 —
+차단한 사람이 보낸 채팅 알림이 목록에 그대로 남아 있으면, 눌러서 들어간 방은 이미 사라진 뒤다.
+
+그래서 목록 RPC에 `private.blocked_user_ids()` 필터를 다는 것까지는 자연스러웠다. 그런데
+**안 읽은 수를 세는 쪽이 따라오지 못한다.**
+
+```sql
+-- 배지: 싸게 세려면 이래야 한다
+select count(*) from notifications where user_id = auth.uid() and is_read = false;
+
+-- 목록: 걸러야 하니 actor를 알아야 하고, actor를 알려면 join 다섯이 필요하다
+```
+
+배지는 3을 가리키는데 열어 보면 한 줄뿐인 화면이 된다. 숫자와 목록이 어긋나면 사용자는 둘 중
+어느 쪽도 믿지 않게 된다.
+
+**원인**: 걸러내기(필터)와 세기(count)의 비용이 다르다. 같은 조건을 양쪽에 걸면 배지 하나를 위해
+목록과 같은 join을 매번 돌려야 하고, 한쪽만 걸면 두 숫자가 어긋난다.
+
+**해결**: 거르는 대신 **차단하는 순간 지운다.** `blocks` after insert 트리거다.
+
+```sql
+create or replace function purge_blocked_notifications()
+returns trigger
+language plpgsql
+security definer set search_path = public
+as $$
+begin
+  delete from notifications n
+   where n.user_id in (new.blocker_id, new.blocked_id)
+     and (
+       exists (select 1 from messages m
+                where m.id = (n.payload ->> 'message_id')::bigint
+                  and m.sender_id in (new.blocker_id, new.blocked_id)
+                  and m.sender_id <> n.user_id)
+       or exists (select 1 from reviews r
+                   where r.id = (n.payload ->> 'review_id')::bigint
+                     and r.reviewer_id in (new.blocker_id, new.blocked_id)
+                     and r.reviewer_id <> n.user_id)
+     );
+  return new;
+end;
+$$;
+```
+
+지우고 나면 목록에 필터가 필요 없고, 배지도 `count(*)` 한 줄이면 된다. 두 숫자가 **같은 행을
+세게 되므로** 어긋날 자리 자체가 없어진다.
+
+`security definer`인 이유는 `notifications`에 delete 정책이 아예 없어서다(0001). 본인 알림을
+지우는 길을 클라이언트에 열어 줄 생각이 없어 정책을 더하지 않고 이 트리거 안에서만 지운다.
+
+양쪽(`blocker_id`·`blocked_id`) 모두에서 지운다. 0014의 `fetch_chat_rooms`가 양방향으로 방을
+감추므로, 한쪽에만 알림이 남으면 눌러도 갈 곳이 없는 알림이 된다.
+
+**교훈**: **"목록에서 걸러낸다"는 결정은 그 목록을 세는 곳까지 따라간다.** 6단계에서 걸러낼 자리를
+넷 찾아 놓고도 알림을 빠뜨렸는데, 그때 빠뜨린 대가가 7단계에서 "필터냐 삭제냐"라는 더 큰 선택으로
+돌아왔다. 거르는 비용과 세는 비용이 다른 자리에서는 **아예 없애는 쪽**이 단순할 때가 있다.
+
+---
+
+### 2. 구독은 성공하는데 이벤트가 오지 않는다
+
+**증상**: `subscribeToMyNotifications`를 `useChatRealtime` 패턴 그대로 짜 놓고 보니,
+`todo.md`가 시킨 대로 했는데도 새 알림이 화면에 반영될 근거가 없었다.
+
+**원인**: `notifications`가 **publication에 들어 있지 않았다.**
+
+```sql
+select tablename from pg_publication_tables where pubname = 'supabase_realtime';
+-- chat_rooms, messages   ← notifications 없음
+```
+
+0008이 `messages`·`chat_rooms`만 넣었다. 그 파일의 주석은 "대시보드에서 켜면 db reset으로
+재현되지 않으므로 여기에 남긴다"고 적어 뒀는데, 정작 그때 없던 테이블은 함께 넣히지 않았다.
+
+무서운 것은 **이것이 오류로 보이지 않는다**는 점이다. `.subscribe()`는 `SUBSCRIBED`를 돌려주고
+채널도 살아 있다. 이벤트만 영원히 오지 않는다. "왜 안 오지"를 클라이언트 쪽에서 찾기 시작하면
+필터 문법·RLS·채널 이름을 차례로 의심하며 한참 헤맨다.
+
+**해결**: 0008과 같은 모양으로 넣는다(`add table`은 이미 있으면 오류라 존재 확인 후 실행).
+
+```sql
+do $$
+begin
+  if not exists (
+    select 1 from pg_publication_tables
+     where pubname = 'supabase_realtime' and schemaname = 'public' and tablename = 'notifications'
+  ) then
+    alter publication supabase_realtime add table notifications;
+  end if;
+end;
+$$;
+```
+
+`replica identity full`은 걸지 않았다. 0008이 `messages`에 그것을 건 이유는 update의 **이전 행**이
+필요해서였는데(읽음 표시), 알림은 insert만 구독한다.
+
+**교훈**: Realtime이 안 될 때 **먼저 볼 곳은 클라이언트가 아니라 `pg_publication_tables`다.**
+조용히 실패하는 설정은 코드를 아무리 들여다봐도 보이지 않는다.
+
+---
+
+### 3. 커서 유틸 테스트가 또 로드 단계에서 죽었다 — 세 번째다
+
+**증상**: `notificationCursor.test.ts`만 스위트째 실패했다.
+
+```
+SyntaxError: Cannot use 'import.meta' outside a module
+  at src/shared/lib/supabaseClient.ts:5
+  at Object.<anonymous> (src/features/notification/api/notificationApi.ts:1:1)
+  at Object.<anonymous> (src/features/notification/utils/notificationCursor.ts:1:1)
+```
+
+**원인**: 「동네 설정」 5번, 「탐색」 1번과 **글자 하나 다르지 않은 문제**다. 커서 유틸이 페이지 크기
+상수 하나(`NOTIFICATIONS_PAGE_SIZE`)를 쓰려고 API 모듈을 import했고, 그것이 `supabaseClient`를
+끌고 들어왔다.
+
+**해결**: 같은 처방. 팩토리와 함께 모듈을 mock한다.
+
+```ts
+jest.mock('../api/notificationApi', function mockNotificationApi() {
+  return { NOTIFICATIONS_PAGE_SIZE: 20 };
+});
+```
+
+**교훈**: 「탐색」 1번에 "이미 한 번 밟은 함정은 같은 구조를 다시 만들 때 다시 밟는다"고 적어 뒀는데
+그대로 다시 밟았다. **세 번 밟았으면 구조를 고칠 때다** — 페이지 크기 상수를 `types.ts`나 별도
+상수 파일로 옮기면 커서 유틸이 API를 import할 이유가 사라진다. 이번에는 기존 셋(`chatCursor`,
+`postSearchCursor`, `myPostCursor`)과 모양을 맞추는 쪽을 골랐지만, 다음에 네 번째가 생기면
+그때는 옮기는 편이 낫다.


### PR DESCRIPTION
## 무엇을

`todo.md` 7단계. `notifications` 테이블도 정책도 0001부터 있었고 트리거 둘이 **이미 행을 쌓고 있었다** — 없던 것은 **읽는 쪽**이다. 채팅·가격제안·후기 알림이 쌓이기만 하고 아무도 보지 않는 상태였다.

## 한 것

1. **`/notifications`** — 알림 목록(탭바 안). 무한 스크롤, 안 읽은 줄 표시, "모두 읽음".
2. **홈 헤더의 종 + 안 읽은 배지** — 마이페이지 메뉴에도 링크를 뒀지만 숫자는 없다. 같은 숫자를 두 곳에 그리면 한쪽만 늦게 갱신될 때 어느 쪽이 맞는지 알 수 없다.
3. **`fetch_notifications`** — `payload jsonb`의 id를 서버가 join 다섯으로 풀어 닉네임·게시물 제목·미리보기까지 준다. 풀지 않으면 화면이 알림 한 줄마다 따로 조회하게 된다.
4. **`notificationText.ts`** — payload를 사람의 말과 이동 경로로 바꾸는 순수 함수. `viewerId`를 받는 이유는 후기 하나 때문이다(받은 후기는 내 프로필에 붙는다).
5. **Realtime 구독** — insert만 보고 무효화한다.

## 마이그레이션 — `0015_notification.sql`

`todo.md`는 "댓글·찜 알림을 넣을 때만 필요"로 적어 뒀지만 손댈 곳이 넷이었다.

- **Realtime publication에 `notifications`가 아예 없었다.** 0008이 `messages`·`chat_rooms`만 넣었다. 없으면 **구독은 조용히 성공하고 이벤트만 영원히 오지 않는다.**
- **`notifications_update`가 payload까지 바꿀 수 있었다.** `auth.uid() = user_id` 하나뿐이라 알림이 가리키는 대상을 사후에 바꿔치기할 수 있었다 → `guard_notification_update`로 잠갔다(0008의 `guard_message_update`와 같은 자리).
- **목록·안 읽은 수 RPC** + 안 읽은 수 전용 부분 인덱스.
- **6단계가 알림에 남긴 구멍** — 차단해도 그 사람의 알림이 그대로 남는다. 목록에서 걸러내면 배지 숫자와 어긋나므로(배지는 싸게 세야 하고 목록은 join이 필요하다) **차단하는 순간 지운다**(`purge_blocked_notifications`).

## 검증

- `npx jest` **77 스위트 · 542건 통과**(신규 4 스위트 23건), `tsc --noEmit`·`eslint` 무경고, `vite build` 성공
- 실제 DB에서 `set local role authenticated`로 사용자를 흉내 내 확인
  - `fetch_notifications()` → 쌓여 있던 알림 1건이 닉네임·게시물 제목·미리보기까지 채워져 나온다
  - payload를 바꾸는 update → `23514 알림은 읽음 표시만 바꿀 수 있습니다.`
  - "모두 읽음" update → 성공, 안 읽은 수 `1 → 0`
  - `purge_blocked_notifications`의 delete 조건 → 두 사람 사이의 알림 1건이 잡힌다
  - `pg_publication_tables` → `chat_rooms`, `messages`, `notifications`

## 이번 범위 밖

- **댓글·찜 알림** — enum에는 있지만 넣는 트리거가 없다(댓글 기능 자체가 없다). `notificationText`는 두 타입을 이미 다루므로 트리거만 더하면 화면은 그대로 굴러간다
- **알림 지우기 · 알림 설정 · 푸시 알림**
- **차단 해제 시 알림 되살리기** — 지운 것이라 돌아오지 않는다(방과 대화는 0014대로 그대로 돌아온다)

구현 노트는 `note.md`의 "알림", 막혔던 부분은 `troble.md`의 같은 절에 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
