### PR TITLE
feature : 비밀번호 변경·회원탈퇴 구현

### DIFF
--- a/note.md
+++ b/note.md
@@ -1990,3 +1990,172 @@ block/hooks/useBlockMutations  ['notifications'] 무효화 추가
   이 단계와 무게가 다르다
 - **차단 해제 시 알림 되살리기** — 지운 것이라 돌아오지 않는다. 알림은 "그때 알려 주는 것"이라
   되돌릴 값이 아니라고 봤다(방과 대화는 0014대로 그대로 돌아온다)
+
+## 계정 — 비밀번호 변경 · 회원탈퇴 (2026-08-05)
+
+`todo.md` 8-1. 앞 일곱 단계와 달리 **DB에 미리 깔려 있던 것이 없는 단계다.** `auth.users`는
+우리 스키마가 아니라 GoTrue의 것이라 마이그레이션으로 손댈 자리가 없고, 그래서 이 단계에는
+마이그레이션이 하나도 없다. 대신 이 프로젝트의 **첫 Edge Function**이 생겼다.
+
+### 무엇을 만들었나
+
+1. **`/settings/account`** — 계정 설정 화면. 마이페이지 메뉴 맨 아래에서 들어간다.
+2. **비밀번호 변경** — 현재 비밀번호로 본인을 확인한 뒤 바꾼다. 구글로만 가입한 사람에게는
+   폼 대신 "로그인에 쓰는 서비스에서 바꿔 주세요"가 보인다.
+3. **회원탈퇴** — `supabase/functions/delete-account`. 확인 문구(`탈퇴합니다`)를 적어야 열린다.
+4. **스토리지 뒷정리** — 행은 FK가 지우지만 버킷의 파일은 아무도 지워 주지 않는다.
+
+### 설계 결정
+
+#### 1. 비밀번호 변경에 현재 비밀번호를 왜 묻는가
+
+`supabase.auth.updateUser({ password })`는 **지금 세션만 있으면 통과한다.** 현재 비밀번호를
+묻지 않는다. 남이 열어 둔 브라우저를 잡으면 비밀번호를 바꿔 계정을 통째로 가져갈 수 있다는 뜻이다.
+
+그래서 바꾸기 전에 한 번 더 로그인한다.
+
+```ts
+// accountApi.changePassword
+const { error: signInError } = await supabase.auth.signInWithPassword({
+  email: input.email, password: input.currentPassword,
+});
+if (signInError !== null) throw signInError;
+
+const { error } = await supabase.auth.updateUser({ password: input.newPassword });
+```
+
+Supabase에도 같은 일을 하는 "Secure password change" 설정이 있지만 대시보드 스위치라
+**코드만 보고는 켜져 있는지 알 수 없다.** 여기서 확실히 한다(개발 편의로 Confirm email을 꺼 둔
+것과 같은 종류의 위험이다 — 대시보드 상태에 기대면 배포 때 잊는다).
+
+이 확인 로그인이 세션을 새로 발급하지만 사용자는 그대로다. `onAuthStateChange`가 새 세션을 받아
+`authStore`를 갱신하므로 화면은 아무 일 없다는 듯 이어진다.
+
+#### 2. "이 계정에 비밀번호가 있는가"는 `identities`로 본다
+
+구글로만 가입한 사람에게 폼을 보여 주면 무엇을 넣어도 통과하지 못하는 막다른 화면이 된다.
+판단 근거로 `app_metadata.provider`를 쓰고 싶어지지만 **그 값은 마지막으로 로그인한 방법 하나**다.
+이메일로 가입한 사람이 구글로 한 번 들어오면 `'google'`이 되고 비밀번호 변경이 사라져 버린다.
+
+진짜 목록은 `user.identities`뿐이다 — 한 계정에 로그인 방법이 여럿 붙을 수 있고(같은 이메일로
+구글을 이어 붙이면 identity가 둘이 된다) 그 전부가 여기 있다. `app_metadata`는 identities가
+없는 응답일 때의 차선책으로만 남겼다(`passwordLogin.ts`, 단위 테스트 5건).
+
+#### 3. 탈퇴는 왜 Edge Function인가 — 그리고 누구를 지우는가
+
+`auth.admin.deleteUser`는 `service_role` 키를 요구한다. 그 키는 RLS를 통째로 무시하므로
+브라우저에 둘 수 없다. 서버가 필요한 첫 자리다.
+
+지울 사람은 **요청에 실린 토큰이 정한다.** 클라이언트는 아무 인자도 넘기지 않는다.
+
+```ts
+// accountApi.deleteAccount — 몸통이 비어 있다
+await supabase.functions.invoke('delete-account', { method: 'POST' });
+```
+
+몸통으로 id를 받으면 남의 id를 적어 보내는 길이 열린다. 함수 안에서도 클라이언트를 둘 만들어,
+**앞의 것(anon 키 + 그 사람의 토큰)은 신원만 판단하고 뒤의 것(service_role)만 지운다.**
+하나로 합치면 service_role 권한으로 신원을 확인하는 셈이 된다.
+
+DB는 손대지 않는다. 0001의 FK가 모두 `on delete cascade`라 `auth.users` 한 행이 사라지면
+profiles → posts · chat_rooms · messages · reviews · notifications · blocks · reports까지
+따라 지워진다. **따라오지 않는 것은 스토리지뿐이고**, 그 뒷정리가 함수가 하는 나머지 일이다.
+
+#### 4. 순서 — 계정 먼저, 파일 나중
+
+```ts
+const roomIds = await fetchRoomIds(admin, userId);   // 행이 살아 있는 동안에만 알 수 있다
+const { error } = await admin.auth.admin.deleteUser(userId);
+if (error !== null) return jsonResponse({ error: error.message }, 500);
+await removeUserFiles(admin, userId, roomIds);       // 실패해도 던지지 않는다
+```
+
+파일을 먼저 지우면 삭제가 실패했을 때 **사진만 사라진 계정**이 남는다. 계정을 먼저 지우면
+실패해도 남는 것은 아무도 안 보는 파일뿐이다. 뒷정리 실패를 무시하는 것은
+`profileApi.removeAvatarObject`·`postApi.removeUploadedImages`와 같은 판단이다.
+
+방 번호를 먼저 읽어 두는 이유는 5번에 있다.
+
+#### 5. 채팅 사진만 경로가 다르다
+
+| 버킷 | 경로 | 훑는 법 |
+| --- | --- | --- |
+| `avatars` | `{user_id}/{stamp}.ext` | 접두사 하나 |
+| `post-images` | `{user_id}/{stamp}-{i}.ext` | 접두사 하나 |
+| `chat-images` | **`{room_id}/{user_id}/…`** | 방 번호를 먼저 알아야 한다 |
+
+0008이 채팅 사진의 첫 칸을 방으로 둔 것은 storage 정책이 "이 방 사람인가"를 봐야 했기 때문이다.
+그 덕에 사용자 접두사로는 훑을 수 없다. 버킷 전체를 훑는 것은 방 수에 비례하는 일이라,
+**삭제 전에 `chat_rooms`에서 내 방 번호를 읽어 두고** `{room_id}/{user_id}` 폴더만 지운다.
+방을 통째로 비우지 않는 이유는 같은 방에 상대가 올린 사진이 함께 들어 있어서다.
+
+#### 6. 탈퇴는 한 번 더 묻는 것으로 모자란다
+
+차단(`blockToggleButton`)·게시물 삭제(`postOwnerMenu`)도 확인 단계를 두지만 그쪽은
+되돌릴 수 있거나 잃는 것이 하나다. 탈퇴는 돌아올 곳이 없다. 그래서 **문구를 직접 적어야**
+버튼이 열리고, 무엇이 사라지는지를 그 자리에서 함께 보여 준다.
+
+확인 화면의 목적은 겁을 주는 것이 아니라 지금 무엇을 지우는지 알고 누르게 하는 것이다.
+
+성공하면 완료 화면이 없다 — 세션이 비는 순간 `RequireMember`가 로그인 화면으로 보내고
+이 컴포넌트는 사라진다. 그때 `signOut()`이 아니라 `signOut({ scope: 'local' })`을 쓴다
+(`troble.md` 같은 절 3번).
+
+### 파일 구성
+
+```
+supabase/functions/delete-account/index.ts   신원 확인(anon) → deleteUser(service_role)
+                                             → 스토리지 세 버킷 뒷정리
+
+account/                                     (새 폴더 — .gitkeep도 없던 자리)
+├─ api/accountApi.ts          changePassword(재로그인 후 변경) · deleteAccount(함수 호출)
+├─ hooks/useAccountMutations.ts
+├─ utils/passwordLogin.ts     identities로 "비밀번호가 있는 계정인가" 판단 (순수 함수)
+├─ utils/validatePasswordChange.ts
+├─ utils/accountErrorMessage.ts
+└─ components/                accountSettingsPage · passwordChangeForm · deleteAccountSection
+
+auth/api/authApi.ts           signOutLocally 추가 (탈퇴 직후용)
+app/router.tsx                /settings/account 추가 (탭바 밖)
+profile/components/myPageMenu 계정 설정 항목 추가
+```
+
+### 검증
+
+`npx jest` 81 스위트 · 563건 통과(신규 4 스위트 21건). `tsc --noEmit`·`eslint` 무경고,
+`vite build` 성공.
+
+Edge Function은 `delete-account` v1로 배포했다(`verify_jwt: true`, status ACTIVE).
+엔드포인트를 직접 두드려 확인한 것은 둘이다.
+
+```
+OPTIONS /functions/v1/delete-account   → 204, 우리 CORS 헤더 그대로
+POST    /functions/v1/delete-account   → 401 {"code":"UNAUTHORIZED_NO_AUTH_HEADER"}
+        (토큰 없이)
+```
+
+첫 줄이 중요하다. `verify_jwt`를 켜 두면 **preflight(OPTIONS)까지 401로 막혀 브라우저에서
+아예 부를 수 없게 되는 것 아닌가**가 이 함수의 유일한 배포 위험이었는데, 게이트웨이가 OPTIONS는
+검사 없이 통과시켰다. 그래서 `verify_jwt`를 끄지 않아도 된다 — 함수 안의 신원 확인 위에
+게이트웨이 검사가 한 겹 더 남는다.
+
+**실제 계정 삭제까지는 확인하지 못했다.** 확인하려면 진짜로 지워도 되는 계정과 그 사람의
+토큰이 필요하다. 앱에서 시험 계정으로 한 번 밟아 보는 것이 남은 검증이다 —
+탈퇴 후 로그인 화면으로 밀려나는지, 그 이메일로 다시 가입되는지, 버킷에 파일이 남지 않았는지.
+
+```bash
+# 재배포가 필요하면
+supabase functions deploy delete-account
+```
+
+### 이번 범위 밖
+
+- **비밀번호 재설정(잊었을 때)** — 로그인 화면의 "비밀번호를 잊으셨나요"다.
+  `resetPasswordForEmail` + 메일로 오는 recovery 링크가 필요한데, 지금은 개발 편의로
+  Confirm email이 꺼져 있어 메일 경로 자체를 시험할 수 없다. 커스텀 SMTP를 붙이는 때
+  함께 한다.
+- **소셜 계정 연결·해제** — 이메일 계정에 구글을 이어 붙이거나 떼는 것(`linkIdentity`).
+  `hasPasswordLogin`이 이미 identity가 여럿인 경우를 다루므로 화면만 얹으면 된다.
+- **탈퇴 사유 수집 · 재가입 제한** — 당근에는 있다. 사유를 남기려면 사용자가 사라진 뒤에도
+  남는 테이블이 필요하고(지금은 전부 cascade), 재가입 제한은 지운 이메일을 어딘가 들고 있어야 해서
+  "지웠다"는 말과 어긋난다.

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,5 +1,6 @@
 import { createBrowserRouter } from 'react-router-dom';
 import AppLayout from './appLayout';
+import AccountSettingsPage from '../features/account/components/accountSettingsPage';
 import AuthCallbackPage from '../features/auth/components/authCallbackPage';
 import SignInPage from '../features/auth/components/signInPage';
 import SignUpPage from '../features/auth/components/signUpPage';
@@ -198,6 +199,17 @@ export const router = createBrowserRouter([
       <RequireOnboarding>
         <RequireMember>
           <ProfileSettingsPage />
+        </RequireMember>
+      </RequireOnboarding>
+    ),
+  },
+  {
+    // 계정 설정도 "한 가지 일을 끝내고 돌아가는" 설정 화면이라 탭바 밖이다.
+    path: '/settings/account',
+    element: (
+      <RequireOnboarding>
+        <RequireMember>
+          <AccountSettingsPage />
         </RequireMember>
       </RequireOnboarding>
     ),

--- a/src/features/account/api/accountApi.ts
+++ b/src/features/account/api/accountApi.ts
@@ -1,0 +1,85 @@
+import { FunctionsHttpError } from '@supabase/supabase-js';
+import { supabase } from '../../../shared/lib/supabaseClient';
+
+export type ChangePasswordInput = {
+  /** 본인 확인용으로 다시 로그인할 때 쓴다. 세션에 있는 이메일을 그대로 넘긴다. */
+  email: string;
+  currentPassword: string;
+  newPassword: string;
+};
+
+const DELETE_ACCOUNT_FUNCTION = 'delete-account';
+
+/**
+ * 비밀번호 변경.
+ *
+ * `updateUser`는 **지금 세션만 있으면 통과한다** — 현재 비밀번호를 묻지 않는다.
+ * 남이 열어 둔 브라우저를 잡으면 비밀번호를 바꿔 계정을 통째로 가져갈 수 있다는 뜻이라,
+ * 바꾸기 전에 signInWithPassword로 본인인지 한 번 확인한다.
+ * (Supabase의 "Secure password change" 설정도 같은 일을 하지만 대시보드 스위치라
+ *  코드만 보고는 켜져 있는지 알 수 없다. 여기서 확실히 한다.)
+ *
+ * 확인 로그인이 세션을 새로 발급하지만 사용자는 그대로다. onAuthStateChange가
+ * 새 세션을 받아 authStore를 갱신하므로 화면은 아무 일 없다는 듯 이어진다.
+ */
+export async function changePassword(input: ChangePasswordInput): Promise<void> {
+  const { error: signInError } = await supabase.auth.signInWithPassword({
+    email: input.email,
+    password: input.currentPassword,
+  });
+
+  if (signInError !== null) {
+    throw signInError;
+  }
+
+  const { error } = await supabase.auth.updateUser({ password: input.newPassword });
+
+  if (error !== null) {
+    throw error;
+  }
+}
+
+/**
+ * Edge Function이 4xx/5xx로 답하면 supabase-js는 본문을 읽지 않고
+ * "Edge Function returned a non-2xx status code"만 준다. 우리가 함수에서 적어 보낸
+ * 이유는 응답 본문에 들어 있으므로 직접 꺼낸다.
+ */
+async function readFunctionErrorMessage(error: unknown): Promise<string | null> {
+  if (!(error instanceof FunctionsHttpError)) {
+    return null;
+  }
+
+  try {
+    const body: unknown = await error.context.json();
+    if (body !== null && typeof body === 'object') {
+      const message = (body as { error?: unknown }).error;
+      if (typeof message === 'string' && message.length > 0) {
+        return message;
+      }
+    }
+  } catch {
+    // 본문이 JSON이 아니면 꺼낼 것이 없다. 원래 오류를 그대로 쓴다.
+  }
+
+  return null;
+}
+
+/**
+ * 회원탈퇴.
+ *
+ * 사용자를 지우려면 `service_role`이 필요한데 그 키는 브라우저에 둘 수 없다.
+ * 그래서 이 프로젝트의 첫 Edge Function을 부른다(`supabase/functions/delete-account`).
+ * 토큰은 supabase-js가 Authorization 헤더에 실어 보내므로 여기서 따로 넘기지 않는다 —
+ * **누구를 지울지는 함수가 그 토큰으로 정한다.** 몸통에 id를 실어 보내면
+ * 남의 id를 적어 보내는 길이 열린다.
+ */
+export async function deleteAccount(): Promise<void> {
+  const { error } = await supabase.functions.invoke(DELETE_ACCOUNT_FUNCTION, {
+    method: 'POST',
+  });
+
+  if (error !== null) {
+    const message = await readFunctionErrorMessage(error);
+    throw message === null ? error : new Error(message);
+  }
+}

--- a/src/features/account/components/accountSettingsPage.tsx
+++ b/src/features/account/components/accountSettingsPage.tsx
@@ -1,0 +1,131 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import DeleteAccountSection from './deleteAccountSection';
+import PasswordChangeForm from './passwordChangeForm';
+import PageSpinner from '../../../shared/ui/pageSpinner';
+import { selectAuthUser, useAuthStore } from '../../auth/store/authStore';
+import { useChangePasswordMutation } from '../hooks/useAccountMutations';
+import { toAccountErrorMessage } from '../utils/accountErrorMessage';
+import { hasPasswordLogin } from '../utils/passwordLogin';
+import type { PasswordChangeValues } from '../types';
+
+const SECTION_CLASS =
+  'flex flex-col gap-4 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm ' +
+  'dark:border-gray-800 dark:bg-gray-950';
+
+/**
+ * 계정 설정 — 비밀번호 변경과 회원탈퇴.
+ *
+ * 프로필 수정(닉네임·사진)과 나누어 둔다. 그쪽은 남에게 보이는 것을 고치는 화면이고
+ * 여기는 계정 자체를 다루는 화면이라, 실수로 탈퇴 버튼 옆에서 닉네임을 만지게 하고 싶지 않다.
+ *
+ * 비밀번호 칸은 구글로만 가입한 사람에게는 보이지 않는다(hasPasswordLogin).
+ * 로그인 가드는 라우터의 RequireMember가 이미 걸었다.
+ */
+function AccountSettingsPage() {
+  const user = useAuthStore(selectAuthUser);
+  const changePasswordMutation = useChangePasswordMutation();
+  const [isChanged, setIsChanged] = useState(false);
+
+  function handleChangePassword(values: PasswordChangeValues): void {
+    if (user?.email === undefined) {
+      return;
+    }
+
+    setIsChanged(false);
+    changePasswordMutation.mutate(
+      {
+        email: user.email,
+        currentPassword: values.currentPassword,
+        newPassword: values.newPassword,
+      },
+      {
+        onSuccess: function markChanged(): void {
+          setIsChanged(true);
+        },
+      },
+    );
+  }
+
+  if (user === null) {
+    return <PageSpinner message="세션을 확인하는 중입니다…" />;
+  }
+
+  const canChangePassword = hasPasswordLogin(user) && user.email !== undefined;
+  const errorMessage =
+    changePasswordMutation.error !== null
+      ? toAccountErrorMessage(changePasswordMutation.error)
+      : null;
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-screen-sm flex-col gap-6 p-6">
+      <header className="flex flex-col gap-2">
+        <Link
+          to="/my"
+          className="text-sm text-gray-500 transition hover:text-gray-700
+                     dark:text-gray-400 dark:hover:text-gray-200"
+        >
+          ← 마이페이지
+        </Link>
+        <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-50">계정 설정</h1>
+        <p className="text-sm text-gray-500 dark:text-gray-400">{user.email ?? ''}</p>
+      </header>
+
+      {canChangePassword ? (
+        <section className={SECTION_CLASS}>
+          <h2 className="text-base font-semibold text-gray-900 dark:text-gray-50">
+            비밀번호 변경
+          </h2>
+
+          {errorMessage !== null ? (
+            <p
+              role="alert"
+              className="rounded-lg border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700
+                         dark:border-red-800 dark:bg-red-950 dark:text-red-300"
+            >
+              {errorMessage}
+            </p>
+          ) : null}
+
+          {isChanged ? (
+            <p
+              role="status"
+              className="rounded-lg border border-emerald-300 bg-emerald-50 px-3 py-2 text-sm
+                         text-emerald-800 dark:border-emerald-800 dark:bg-emerald-950
+                         dark:text-emerald-200"
+            >
+              비밀번호를 변경했습니다.
+            </p>
+          ) : null}
+
+          {/*
+            성공하면 key가 바뀌어 폼이 빈 값으로 다시 선다.
+            입력한 비밀번호 셋을 화면에 남겨 둘 이유가 없다.
+          */}
+          <PasswordChangeForm
+            key={isChanged ? 'changed' : 'editing'}
+            isPending={changePasswordMutation.isPending}
+            onSubmit={handleChangePassword}
+          />
+        </section>
+      ) : (
+        <section className={SECTION_CLASS}>
+          <h2 className="text-base font-semibold text-gray-900 dark:text-gray-50">
+            로그인 방법
+          </h2>
+          <p className="text-sm leading-relaxed text-gray-600 dark:text-gray-300">
+            소셜 계정으로 로그인하고 있어 가지마켓에는 비밀번호가 없어요. 비밀번호는 로그인에
+            쓰는 서비스에서 바꿔 주세요.
+          </p>
+        </section>
+      )}
+
+      <section className={SECTION_CLASS}>
+        <h2 className="text-base font-semibold text-gray-900 dark:text-gray-50">회원탈퇴</h2>
+        <DeleteAccountSection />
+      </section>
+    </main>
+  );
+}
+
+export default AccountSettingsPage;

--- a/src/features/account/components/deleteAccountSection.test.tsx
+++ b/src/features/account/components/deleteAccountSection.test.tsx
@@ -1,0 +1,113 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DeleteAccountSection from './deleteAccountSection';
+
+// accountApi·authApi는 supabaseClient(import.meta)에 닿는다. ts-jest가 CommonJS로 옮기면서
+// import.meta를 그대로 뱉으므로 실제 모듈을 로드하면 죽는다(troble.md 참고).
+const mockDeleteAccount = jest.fn();
+const mockSignOutLocally = jest.fn();
+
+jest.mock('../api/accountApi', function mockAccountApi() {
+  return {
+    deleteAccount: function deleteAccount() {
+      return mockDeleteAccount();
+    },
+    changePassword: function changePassword() {
+      return Promise.resolve();
+    },
+  };
+});
+
+jest.mock('../../auth/api/authApi', function mockAuthApi() {
+  return {
+    signOutLocally: function signOutLocally() {
+      return mockSignOutLocally();
+    },
+  };
+});
+
+function renderSection() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <DeleteAccountSection />
+    </QueryClientProvider>,
+  );
+}
+
+describe('DeleteAccountSection', function deleteAccountSectionSuite() {
+  beforeEach(function resetMocks() {
+    jest.clearAllMocks();
+    mockDeleteAccount.mockResolvedValue(undefined);
+    mockSignOutLocally.mockResolvedValue(undefined);
+  });
+
+  it('처음에는 확인 화면을 보여주지 않는다', function initialCase() {
+    renderSection();
+
+    expect(screen.getByRole('button', { name: '회원탈퇴' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '탈퇴하기' })).not.toBeInTheDocument();
+  });
+
+  it('확인 화면은 무엇이 사라지는지 함께 보여준다', async function lossListCase() {
+    renderSection();
+
+    await userEvent.click(screen.getByRole('button', { name: '회원탈퇴' }));
+
+    expect(screen.getByText('올린 게시물과 사진')).toBeInTheDocument();
+    expect(screen.getByText('주고받은 채팅과 대화 내용')).toBeInTheDocument();
+  });
+
+  // 되돌릴 수 없는 일이라 "한 번 더 누르기"로는 모자라다.
+  it('확인 문구를 적기 전에는 탈퇴 버튼이 잠겨 있다', async function lockedCase() {
+    renderSection();
+
+    await userEvent.click(screen.getByRole('button', { name: '회원탈퇴' }));
+    expect(screen.getByRole('button', { name: '탈퇴하기' })).toBeDisabled();
+
+    await userEvent.type(screen.getByLabelText(/탈퇴합니다.*입력해 주세요/), '탈퇴');
+    expect(screen.getByRole('button', { name: '탈퇴하기' })).toBeDisabled();
+    expect(mockDeleteAccount).not.toHaveBeenCalled();
+  });
+
+  it('문구를 정확히 적으면 탈퇴하고 이 기기의 세션을 걷어낸다', async function deleteCase() {
+    renderSection();
+
+    await userEvent.click(screen.getByRole('button', { name: '회원탈퇴' }));
+    await userEvent.type(screen.getByLabelText(/탈퇴합니다.*입력해 주세요/), '탈퇴합니다');
+    await userEvent.click(screen.getByRole('button', { name: '탈퇴하기' }));
+
+    await waitFor(function assertDeleted() {
+      expect(mockDeleteAccount).toHaveBeenCalledTimes(1);
+    });
+    expect(mockSignOutLocally).toHaveBeenCalledTimes(1);
+  });
+
+  it('취소하면 아무 일도 일어나지 않는다', async function cancelCase() {
+    renderSection();
+
+    await userEvent.click(screen.getByRole('button', { name: '회원탈퇴' }));
+    await userEvent.type(screen.getByLabelText(/탈퇴합니다.*입력해 주세요/), '탈퇴합니다');
+    await userEvent.click(screen.getByRole('button', { name: '취소' }));
+
+    expect(mockDeleteAccount).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: '회원탈퇴' })).toBeInTheDocument();
+  });
+
+  it('실패하면 이유를 보여준다', async function errorCase() {
+    mockDeleteAccount.mockRejectedValue(new Error('Failed to fetch'));
+    renderSection();
+
+    await userEvent.click(screen.getByRole('button', { name: '회원탈퇴' }));
+    await userEvent.type(screen.getByLabelText(/탈퇴합니다.*입력해 주세요/), '탈퇴합니다');
+    await userEvent.click(screen.getByRole('button', { name: '탈퇴하기' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      '네트워크 연결을 확인해 주세요.',
+    );
+  });
+});

--- a/src/features/account/components/deleteAccountSection.tsx
+++ b/src/features/account/components/deleteAccountSection.tsx
@@ -1,0 +1,126 @@
+import { useState } from 'react';
+import TextField from '../../../shared/ui/textField';
+import { useDeleteAccountMutation } from '../hooks/useAccountMutations';
+import { toAccountErrorMessage } from '../utils/accountErrorMessage';
+
+const CONFIRM_PHRASE = '탈퇴합니다';
+
+/** 탈퇴하면 사라지는 것들. 되돌릴 수 없다는 말보다 목록이 더 정확하다. */
+const LOSS_ITEMS: ReadonlyArray<string> = [
+  '올린 게시물과 사진',
+  '주고받은 채팅과 대화 내용',
+  '받은 후기와 매너온도',
+  '찜·최근 본 글·차단 목록',
+];
+
+/**
+ * 회원탈퇴 — 이 화면에서 가장 위험한 자리라 두 단계로 나눈다.
+ *
+ * 차단(blockToggleButton)도 한 번 더 묻지만 그쪽은 해제하면 그만이다. 탈퇴는 돌아올 곳이
+ * 없어서 "한 번 더 누르기"로는 모자라다고 봤다 — **문구를 직접 적어야** 버튼이 열린다.
+ * 무엇이 사라지는지도 그 자리에서 함께 보여 준다. 확인 화면의 목적은 겁을 주는 것이 아니라
+ * 지금 무엇을 지우는지 알고 누르게 하는 것이다.
+ *
+ * 탈퇴에 성공하면 세션이 비고 RequireMember가 로그인 화면으로 보낸다(useAccountMutations).
+ * 그래서 여기에는 완료 화면이 없다 — 이 컴포넌트는 그 순간 사라진다.
+ */
+function DeleteAccountSection() {
+  const [isConfirming, setIsConfirming] = useState(false);
+  const [phrase, setPhrase] = useState('');
+  const deleteAccountMutation = useDeleteAccountMutation();
+
+  const canDelete = phrase.trim() === CONFIRM_PHRASE;
+
+  function startConfirm(): void {
+    setPhrase('');
+    setIsConfirming(true);
+  }
+
+  function cancelConfirm(): void {
+    setIsConfirming(false);
+    setPhrase('');
+  }
+
+  function handleDelete(): void {
+    if (!canDelete) {
+      return;
+    }
+    deleteAccountMutation.mutate();
+  }
+
+  if (!isConfirming) {
+    return (
+      <div className="flex flex-col gap-3">
+        <p className="text-sm leading-relaxed text-gray-600 dark:text-gray-300">
+          탈퇴하면 계정과 그동안의 활동이 모두 지워지고 되돌릴 수 없어요.
+        </p>
+        <button
+          type="button"
+          onClick={startConfirm}
+          className="self-start rounded-lg border border-red-300 px-4 py-2 text-sm font-semibold
+                     text-red-600 transition hover:bg-red-50
+                     dark:border-red-800 dark:text-red-400 dark:hover:bg-red-950"
+        >
+          회원탈퇴
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-2">
+        <p className="text-sm font-semibold text-gray-900 dark:text-gray-50">
+          탈퇴하면 아래가 모두 사라져요.
+        </p>
+        <ul className="flex flex-col gap-1 pl-4 text-sm text-gray-600 dark:text-gray-300">
+          {LOSS_ITEMS.map(function renderLossItem(item: string) {
+            return (
+              <li key={item} className="list-disc">
+                {item}
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+
+      <TextField
+        id="deleteConfirmPhrase"
+        label={`확인을 위해 "${CONFIRM_PHRASE}"를 입력해 주세요`}
+        value={phrase}
+        placeholder={CONFIRM_PHRASE}
+        disabled={deleteAccountMutation.isPending}
+        onValueChange={setPhrase}
+      />
+
+      <div className="flex gap-2">
+        <button
+          type="button"
+          disabled={!canDelete || deleteAccountMutation.isPending}
+          onClick={handleDelete}
+          className="rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold text-white transition
+                     hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {deleteAccountMutation.isPending ? '탈퇴하는 중…' : '탈퇴하기'}
+        </button>
+        <button
+          type="button"
+          disabled={deleteAccountMutation.isPending}
+          onClick={cancelConfirm}
+          className="rounded-lg px-4 py-2 text-sm text-gray-600 transition hover:text-gray-800
+                     disabled:opacity-60 dark:text-gray-300 dark:hover:text-gray-100"
+        >
+          취소
+        </button>
+      </div>
+
+      {deleteAccountMutation.error === null ? null : (
+        <p role="alert" className="text-sm text-red-600 dark:text-red-400">
+          {toAccountErrorMessage(deleteAccountMutation.error)}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default DeleteAccountSection;

--- a/src/features/account/components/passwordChangeForm.test.tsx
+++ b/src/features/account/components/passwordChangeForm.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PasswordChangeForm from './passwordChangeForm';
+
+async function fill(current: string, next: string, confirm: string): Promise<void> {
+  await userEvent.type(screen.getByLabelText('현재 비밀번호'), current);
+  await userEvent.type(screen.getByLabelText('새 비밀번호'), next);
+  await userEvent.type(screen.getByLabelText('새 비밀번호 확인'), confirm);
+  await userEvent.click(screen.getByRole('button', { name: '비밀번호 변경' }));
+}
+
+describe('PasswordChangeForm', function passwordChangeFormSuite() {
+  it('올바른 입력이면 onSubmit을 호출한다', async function validCase() {
+    const handleSubmit = jest.fn();
+    render(<PasswordChangeForm isPending={false} onSubmit={handleSubmit} />);
+
+    await fill('eggplant1234', 'eggplant5678', 'eggplant5678');
+
+    expect(handleSubmit).toHaveBeenCalledWith({
+      currentPassword: 'eggplant1234',
+      newPassword: 'eggplant5678',
+      newPasswordConfirm: 'eggplant5678',
+    });
+  });
+
+  it('확인 값이 다르면 오류를 보여주고 보내지 않는다', async function mismatchCase() {
+    const handleSubmit = jest.fn();
+    render(<PasswordChangeForm isPending={false} onSubmit={handleSubmit} />);
+
+    await fill('eggplant1234', 'eggplant5678', 'eggplant9999');
+
+    expect(await screen.findByText('비밀번호가 일치하지 않습니다.')).toBeInTheDocument();
+    expect(handleSubmit).not.toHaveBeenCalled();
+  });
+
+  // 서버도 거절하지만(same_password) 화면이 알아볼 수 있는 것을 왕복시킬 이유가 없다.
+  it('지금과 같은 비밀번호는 보내지 않는다', async function samePasswordCase() {
+    const handleSubmit = jest.fn();
+    render(<PasswordChangeForm isPending={false} onSubmit={handleSubmit} />);
+
+    await fill('eggplant1234', 'eggplant1234', 'eggplant1234');
+
+    expect(
+      await screen.findByText('지금 쓰고 있는 비밀번호와 다른 비밀번호를 입력해 주세요.'),
+    ).toBeInTheDocument();
+    expect(handleSubmit).not.toHaveBeenCalled();
+  });
+
+  it('처리 중에는 버튼이 잠긴다', function pendingCase() {
+    render(<PasswordChangeForm isPending onSubmit={jest.fn()} />);
+
+    expect(screen.getByRole('button', { name: '변경 중…' })).toBeDisabled();
+  });
+});

--- a/src/features/account/components/passwordChangeForm.tsx
+++ b/src/features/account/components/passwordChangeForm.tsx
@@ -1,0 +1,102 @@
+import { useState, type FormEvent } from 'react';
+import AuthTextField from '../../auth/components/authTextField';
+import SubmitButton from '../../../shared/ui/submitButton';
+import {
+  hasPasswordChangeError,
+  validatePasswordChangeValues,
+} from '../utils/validatePasswordChange';
+import type { PasswordChangeFieldErrors, PasswordChangeValues } from '../types';
+
+type PasswordChangeFormProps = {
+  isPending: boolean;
+  onSubmit(values: PasswordChangeValues): void;
+};
+
+const EMPTY_VALUES: PasswordChangeValues = {
+  currentPassword: '',
+  newPassword: '',
+  newPasswordConfirm: '',
+};
+
+/**
+ * 비밀번호 변경 폼 — 값만 다룬다. 부르는 쪽(accountSettingsPage)이 계정을 안다.
+ *
+ * 입력이 로그인 폼과 같은 모양이라 인증 폼의 AuthTextField를 그대로 쓴다.
+ * autoComplete는 브라우저 비밀번호 관리자가 알아듣는 이름이어야 한다 —
+ * 현재 것은 current-password, 새 것 둘은 new-password다. 셋 다 new-password로 두면
+ * 관리자가 옛 비밀번호를 새 칸에 채워 넣는다.
+ */
+function PasswordChangeForm(props: PasswordChangeFormProps) {
+  const [values, setValues] = useState<PasswordChangeValues>(EMPTY_VALUES);
+  const [errors, setErrors] = useState<PasswordChangeFieldErrors>({});
+
+  function updateField(field: keyof PasswordChangeValues, value: string): void {
+    setValues(function mergeField(previous) {
+      return { ...previous, [field]: value };
+    });
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault();
+
+    const nextErrors = validatePasswordChangeValues(values);
+    setErrors(nextErrors);
+    if (hasPasswordChangeError(nextErrors)) {
+      return;
+    }
+
+    props.onSubmit(values);
+  }
+
+  return (
+    <form noValidate onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <AuthTextField
+        id="currentPassword"
+        label="현재 비밀번호"
+        type="password"
+        value={values.currentPassword}
+        autoComplete="current-password"
+        errorMessage={errors.currentPassword}
+        disabled={props.isPending}
+        onValueChange={function changeCurrentPassword(value: string): void {
+          updateField('currentPassword', value);
+        }}
+      />
+
+      <AuthTextField
+        id="newPassword"
+        label="새 비밀번호"
+        type="password"
+        value={values.newPassword}
+        autoComplete="new-password"
+        placeholder="8자 이상"
+        errorMessage={errors.newPassword}
+        disabled={props.isPending}
+        onValueChange={function changeNewPassword(value: string): void {
+          updateField('newPassword', value);
+        }}
+      />
+
+      <AuthTextField
+        id="newPasswordConfirm"
+        label="새 비밀번호 확인"
+        type="password"
+        value={values.newPasswordConfirm}
+        autoComplete="new-password"
+        errorMessage={errors.newPasswordConfirm}
+        disabled={props.isPending}
+        onValueChange={function changeNewPasswordConfirm(value: string): void {
+          updateField('newPasswordConfirm', value);
+        }}
+      />
+
+      <SubmitButton
+        label="비밀번호 변경"
+        pendingLabel="변경 중…"
+        isPending={props.isPending}
+      />
+    </form>
+  );
+}
+
+export default PasswordChangeForm;

--- a/src/features/account/hooks/useAccountMutations.ts
+++ b/src/features/account/hooks/useAccountMutations.ts
@@ -1,0 +1,41 @@
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+import { changePassword, deleteAccount, type ChangePasswordInput } from '../api/accountApi';
+import { signOutLocally } from '../../auth/api/authApi';
+import { selectClearSession, useAuthStore } from '../../auth/store/authStore';
+
+/** 비밀번호 변경은 캐시에 남는 것이 없다. 사용자도 세션도 그대로다. */
+export function useChangePasswordMutation(): UseMutationResult<
+  void,
+  Error,
+  ChangePasswordInput
+> {
+  return useMutation<void, Error, ChangePasswordInput>({
+    mutationFn: changePassword,
+  });
+}
+
+/**
+ * 회원탈퇴.
+ *
+ * 계정이 사라진 뒤에도 이 브라우저에는 토큰과 쿼리 캐시가 남아 있다. 그대로 두면
+ * 화면이 이미 없는 사람의 프로필을 계속 그리다가 다음 요청에서야 401을 만난다.
+ * 그래서 지우자마자 이 기기의 세션을 걷어내고(signOutLocally) 캐시를 비운다 —
+ * 로그아웃(useSignOutMutation)이 하는 뒷정리와 같고, 로그아웃 쪽만 서버에도 알린다.
+ *
+ * 세션이 비면 RequireMember가 로그인 화면으로 보내므로 따로 navigate하지 않는다.
+ */
+export function useDeleteAccountMutation(): UseMutationResult<void, Error, void> {
+  const queryClient = useQueryClient();
+  const clearSession = useAuthStore(selectClearSession);
+
+  return useMutation<void, Error, void>({
+    mutationFn: async function removeAccount(): Promise<void> {
+      await deleteAccount();
+      await signOutLocally();
+    },
+    onSuccess: function handleDeleted(): void {
+      clearSession();
+      queryClient.clear();
+    },
+  });
+}

--- a/src/features/account/types.ts
+++ b/src/features/account/types.ts
@@ -1,0 +1,9 @@
+export type PasswordChangeValues = {
+  currentPassword: string;
+  newPassword: string;
+  newPasswordConfirm: string;
+};
+
+export type PasswordChangeFieldName = keyof PasswordChangeValues;
+
+export type PasswordChangeFieldErrors = Partial<Record<PasswordChangeFieldName, string>>;

--- a/src/features/account/utils/accountErrorMessage.ts
+++ b/src/features/account/utils/accountErrorMessage.ts
@@ -1,0 +1,25 @@
+// 비밀번호 변경·회원탈퇴 오류를 사용자에게 보여줄 한국어 문구로 바꾼다.
+
+import { matchErrorMessage } from '../../../shared/utils/errorText';
+
+const DEFAULT_ACCOUNT_ERROR_MESSAGE =
+  '요청을 처리하지 못했습니다. 잠시 후 다시 시도해 주세요.';
+
+// 순서가 곧 우선순위다. 구체적인 원인을 위에 둔다.
+//
+// invalid_credentials가 여기서는 "로그인 실패"가 아니라 "현재 비밀번호가 틀렸다"는 뜻이다 —
+// changePassword가 본인 확인으로 signInWithPassword를 한 번 거치기 때문이다(accountApi).
+const MESSAGE_BY_PATTERN: ReadonlyArray<readonly [RegExp, string]> = [
+  [/invalid_credentials|invalid login credentials/, '현재 비밀번호가 올바르지 않습니다.'],
+  [/same_password|should be different from the old password/, '지금 쓰고 있는 비밀번호와 다른 비밀번호를 입력해 주세요.'],
+  [/weak_password|password should be at least/, '비밀번호가 너무 단순합니다. 더 복잡하게 설정해 주세요.'],
+  [/reauthentication|session_not_found|refresh_token_not_found|bad_jwt/, '로그인이 만료되었습니다. 다시 로그인해 주세요.'],
+  [/rate limit|too many requests/, '요청이 너무 잦습니다. 잠시 후 다시 시도해 주세요.'],
+  // Edge Function이 아직 배포되지 않았거나 이름이 다를 때. 사용자가 할 수 있는 일은 없다.
+  [/not found|failed to send a request|non-2xx/, '탈퇴 요청이 서버에 닿지 못했습니다. 잠시 후 다시 시도해 주세요.'],
+  [/failed to fetch|network|networkerror/, '네트워크 연결을 확인해 주세요.'],
+];
+
+export function toAccountErrorMessage(error: unknown): string {
+  return matchErrorMessage(error, MESSAGE_BY_PATTERN, DEFAULT_ACCOUNT_ERROR_MESSAGE);
+}

--- a/src/features/account/utils/passwordLogin.test.ts
+++ b/src/features/account/utils/passwordLogin.test.ts
@@ -1,0 +1,55 @@
+import { hasPasswordLogin } from './passwordLogin';
+import type { AuthUser } from '../../auth/types';
+
+type UserShape = {
+  identities?: Array<{ provider: string }> | null;
+  app_metadata?: { provider?: string; providers?: string[] };
+};
+
+function makeUser(shape: UserShape): AuthUser {
+  return { id: 'user-1', ...shape } as unknown as AuthUser;
+}
+
+describe('hasPasswordLogin', function passwordLoginSuite() {
+  it('이메일 identity가 있으면 비밀번호 로그인이다', function emailIdentityCase() {
+    const user = makeUser({
+      identities: [{ provider: 'email' }],
+      app_metadata: { provider: 'email', providers: ['email'] },
+    });
+
+    expect(hasPasswordLogin(user)).toBe(true);
+  });
+
+  it('구글 identity만 있으면 바꿀 비밀번호가 없다', function googleOnlyCase() {
+    const user = makeUser({
+      identities: [{ provider: 'google' }],
+      app_metadata: { provider: 'google', providers: ['google'] },
+    });
+
+    expect(hasPasswordLogin(user)).toBe(false);
+  });
+
+  // app_metadata.provider는 "마지막으로 로그인한 방법"이라 이메일 가입자가 구글로 한 번
+  // 들어오면 'google'이 된다. 그것만 보면 비밀번호 변경이 사라져 버린다.
+  it('구글로 마지막에 로그인했어도 이메일 identity가 남아 있으면 바꿀 수 있다', function mixedCase() {
+    const user = makeUser({
+      identities: [{ provider: 'email' }, { provider: 'google' }],
+      app_metadata: { provider: 'google', providers: ['email', 'google'] },
+    });
+
+    expect(hasPasswordLogin(user)).toBe(true);
+  });
+
+  it('identities가 없으면 app_metadata로 판단한다', function fallbackCase() {
+    expect(
+      hasPasswordLogin(makeUser({ app_metadata: { providers: ['email'] } })),
+    ).toBe(true);
+    expect(hasPasswordLogin(makeUser({ app_metadata: { provider: 'email' } }))).toBe(true);
+    expect(hasPasswordLogin(makeUser({ app_metadata: { provider: 'google' } }))).toBe(false);
+    expect(hasPasswordLogin(makeUser({ identities: null }))).toBe(false);
+  });
+
+  it('로그인하지 않았으면 false다', function guestCase() {
+    expect(hasPasswordLogin(null)).toBe(false);
+  });
+});

--- a/src/features/account/utils/passwordLogin.ts
+++ b/src/features/account/utils/passwordLogin.ts
@@ -1,0 +1,44 @@
+import type { AuthUser } from '../../auth/types';
+
+/**
+ * 이 계정이 비밀번호로도 로그인하는가.
+ *
+ * 구글로만 가입한 사람에게는 바꿀 비밀번호가 없다. 그런 사람에게 폼을 보여 주면
+ * "현재 비밀번호"에 무엇을 넣어도 통과하지 못하는 막다른 화면이 된다 — 그래서 감춘다.
+ *
+ * 판단은 `identities`를 먼저 본다. 한 계정에 로그인 방법이 여럿 붙을 수 있고
+ * (같은 이메일로 구글을 이어 붙이면 identity가 둘이 된다) 그때 진짜 목록은 여기뿐이다.
+ * `app_metadata.provider`는 **마지막으로 로그인한 방법 하나**라서, 이메일로 가입한 사람이
+ * 구글로 한 번 들어오면 'google'로 바뀌어 비밀번호 변경이 사라져 버린다.
+ * identities가 없는 응답(옛 세션·축약된 사용자)일 때만 app_metadata로 물러난다.
+ */
+
+const PASSWORD_PROVIDER = 'email';
+
+type AuthAppMetadata = {
+  provider?: string;
+  providers?: string[];
+};
+
+export function hasPasswordLogin(user: AuthUser | null): boolean {
+  if (user === null) {
+    return false;
+  }
+
+  const identities = user.identities;
+  if (identities !== undefined && identities !== null) {
+    return identities.some(function isPasswordIdentity(identity): boolean {
+      return identity.provider === PASSWORD_PROVIDER;
+    });
+  }
+
+  const metadata = user.app_metadata as AuthAppMetadata | undefined;
+  if (metadata === undefined) {
+    return false;
+  }
+  if (Array.isArray(metadata.providers)) {
+    return metadata.providers.includes(PASSWORD_PROVIDER);
+  }
+
+  return metadata.provider === PASSWORD_PROVIDER;
+}

--- a/src/features/account/utils/validatePasswordChange.test.ts
+++ b/src/features/account/utils/validatePasswordChange.test.ts
@@ -1,0 +1,61 @@
+import {
+  hasPasswordChangeError,
+  validatePasswordChangeValues,
+} from './validatePasswordChange';
+import type { PasswordChangeValues } from '../types';
+
+function makeValues(overrides: Partial<PasswordChangeValues> = {}): PasswordChangeValues {
+  return {
+    currentPassword: 'eggplant1234',
+    newPassword: 'eggplant5678',
+    newPasswordConfirm: 'eggplant5678',
+    ...overrides,
+  };
+}
+
+describe('validatePasswordChangeValues', function validatePasswordChangeSuite() {
+  it('올바른 입력이면 오류가 없다', function validCase() {
+    const errors = validatePasswordChangeValues(makeValues());
+
+    expect(hasPasswordChangeError(errors)).toBe(false);
+  });
+
+  it('현재 비밀번호가 비면 막는다', function emptyCurrentCase() {
+    const errors = validatePasswordChangeValues(makeValues({ currentPassword: '' }));
+
+    expect(errors.currentPassword).toBe('현재 비밀번호를 입력해 주세요.');
+  });
+
+  // 규칙이 느슨하던 시절의 비밀번호일 수 있다. 여기서 막으면 바꿀 길 자체가 없어진다.
+  it('현재 비밀번호에는 길이 규칙을 걸지 않는다', function shortCurrentCase() {
+    const errors = validatePasswordChangeValues(makeValues({ currentPassword: 'old' }));
+
+    expect(errors.currentPassword).toBeUndefined();
+  });
+
+  it('새 비밀번호에는 가입 때와 같은 규칙을 건다', function weakNewCase() {
+    const errors = validatePasswordChangeValues(
+      makeValues({ newPassword: 'egg', newPasswordConfirm: 'egg' }),
+    );
+
+    expect(errors.newPassword).toBe('비밀번호는 8자 이상이어야 합니다.');
+  });
+
+  it('지금과 같은 비밀번호는 미리 걸러낸다', function samePasswordCase() {
+    const errors = validatePasswordChangeValues(
+      makeValues({ newPassword: 'eggplant1234', newPasswordConfirm: 'eggplant1234' }),
+    );
+
+    expect(errors.newPassword).toBe(
+      '지금 쓰고 있는 비밀번호와 다른 비밀번호를 입력해 주세요.',
+    );
+  });
+
+  it('확인 값이 다르면 막는다', function confirmMismatchCase() {
+    const errors = validatePasswordChangeValues(
+      makeValues({ newPasswordConfirm: 'eggplant9999' }),
+    );
+
+    expect(errors.newPasswordConfirm).toBe('비밀번호가 일치하지 않습니다.');
+  });
+});

--- a/src/features/account/utils/validatePasswordChange.ts
+++ b/src/features/account/utils/validatePasswordChange.ts
@@ -1,0 +1,47 @@
+import {
+  validatePassword,
+  validatePasswordConfirm,
+} from '../../auth/utils/validateAuthInput';
+import type { PasswordChangeFieldErrors, PasswordChangeValues } from '../types';
+
+/**
+ * 비밀번호 변경 입력 검사.
+ *
+ * 새 비밀번호에만 가입 때와 같은 규칙(validatePassword)을 건다.
+ * **현재 비밀번호는 비었는지만 본다** — 규칙이 느슨하던 시절에 만든 비밀번호일 수 있고,
+ * 여기서 막으면 정작 맞는 비밀번호를 들고도 바꿀 길이 없어진다. 맞는지 틀리는지는
+ * 어차피 서버가 답한다.
+ *
+ * 같은 비밀번호는 미리 걸러낸다. 서버도 거절하지만(same_password) 그 왕복은
+ * 화면이 알아볼 수 있는 것을 굳이 물어보는 셈이다.
+ */
+export function validatePasswordChangeValues(
+  values: PasswordChangeValues,
+): PasswordChangeFieldErrors {
+  const errors: PasswordChangeFieldErrors = {};
+
+  if (values.currentPassword.length === 0) {
+    errors.currentPassword = '현재 비밀번호를 입력해 주세요.';
+  }
+
+  const newPasswordError = validatePassword(values.newPassword);
+  if (newPasswordError !== undefined) {
+    errors.newPassword = newPasswordError;
+  } else if (values.newPassword === values.currentPassword) {
+    errors.newPassword = '지금 쓰고 있는 비밀번호와 다른 비밀번호를 입력해 주세요.';
+  }
+
+  const confirmError = validatePasswordConfirm(
+    values.newPassword,
+    values.newPasswordConfirm,
+  );
+  if (confirmError !== undefined) {
+    errors.newPasswordConfirm = confirmError;
+  }
+
+  return errors;
+}
+
+export function hasPasswordChangeError(errors: PasswordChangeFieldErrors): boolean {
+  return Object.keys(errors).length > 0;
+}

--- a/src/features/auth/api/authApi.ts
+++ b/src/features/auth/api/authApi.ts
@@ -67,6 +67,21 @@ export async function signOut(): Promise<void> {
   }
 }
 
+/**
+ * 이 기기의 토큰만 지운다(서버에 로그아웃을 알리지 않는다).
+ *
+ * 회원탈퇴 직후에 쓴다. 그때는 계정이 이미 없어서 보통 로그아웃(`scope: 'global'`)이
+ * 401로 실패하고, 실패하면 supabase-js가 저장소의 토큰을 남겨 둔다 —
+ * 새로고침하면 죽은 세션으로 다시 서는 자리다.
+ */
+export async function signOutLocally(): Promise<void> {
+  const { error } = await supabase.auth.signOut({ scope: 'local' });
+
+  if (error !== null) {
+    throw error;
+  }
+}
+
 export async function getCurrentSession(): Promise<AuthSession | null> {
   const { data, error } = await supabase.auth.getSession();
 

--- a/src/features/profile/components/myPageMenu.tsx
+++ b/src/features/profile/components/myPageMenu.tsx
@@ -8,7 +8,9 @@ type MyPageMenuItem = {
 
 /**
  * 마이페이지에서 갈 수 있는 곳. 순서는 자주 여는 것부터다.
- * 차단 목록은 맨 아래다 — 거래하다 한 번 들를까 말까 한 관리 화면이다.
+ * 차단 목록·계정 설정이 맨 아래다 — 거래하다 한 번 들를까 말까 한 관리 화면이다.
+ * 계정 설정(비밀번호·탈퇴)은 그중에서도 마지막이다. 프로필 수정·동네 설정은
+ * 자주 여는 자리라 목록이 아니라 카드(myProfileCard)의 버튼으로 두었다.
  *
  * 알림에는 안 읽은 배지를 달지 않는다. 배지는 홈 헤더의 종 하나뿐이다 —
  * 같은 숫자를 두 곳에 그리면 한쪽만 늦게 갱신될 때 어느 쪽이 맞는지 알 수 없다.
@@ -21,6 +23,7 @@ const MENU_ITEMS: ReadonlyArray<MyPageMenuItem> = [
   { to: '/my/purchases', icon: '🧾', label: '구매내역' },
   { to: '/my/sales', icon: '📦', label: '판매관리' },
   { to: '/my/blocks', icon: '🚫', label: '차단 목록' },
+  { to: '/settings/account', icon: '⚙️', label: '계정 설정' },
 ];
 
 function MyPageMenu() {

--- a/supabase/functions/delete-account/index.ts
+++ b/supabase/functions/delete-account/index.ts
@@ -1,0 +1,185 @@
+// 회원탈퇴 — 이 프로젝트의 첫 Edge Function.
+//
+// 브라우저에서는 사용자를 지울 수 없다. `auth.admin.deleteUser`가 service_role 키를 요구하는데
+// 그 키는 클라이언트에 둘 수 없기 때문이다. 그래서 여기서만 그 키를 쓴다.
+//
+// 지우는 사람은 **요청에 실린 토큰이 정한다.** 몸통에서 id를 받으면 남의 id를 적어 보내는 길이
+// 열린다. 그래서 클라이언트가 부를 때 아무 인자도 넘기지 않는다(accountApi.deleteAccount).
+//
+// DB는 손대지 않는다. 0001의 FK가 모두 `on delete cascade`라 auth.users 한 행이 사라지면
+// profiles → posts·chat_rooms·messages·reviews·notifications·blocks·reports까지 따라 지워진다.
+// **스토리지만 따라오지 않는다** — 버킷의 파일은 DB 행이 아니라 아무 참조도 없이 남는다.
+// 그 뒷정리가 이 함수가 하는 나머지 일이다.
+//
+// 배포: supabase functions deploy delete-account
+//   (SUPABASE_URL·SUPABASE_ANON_KEY·SUPABASE_SERVICE_ROLE_KEY는 런타임이 자동으로 넣어 준다)
+
+import { createClient, type SupabaseClient } from 'npm:@supabase/supabase-js@2';
+
+const CORS_HEADERS: Record<string, string> = {
+  'access-control-allow-origin': '*',
+  'access-control-allow-headers': 'authorization, x-client-info, apikey, content-type',
+  'access-control-allow-methods': 'POST, OPTIONS',
+};
+
+/** 경로 첫 칸이 사용자 id인 버킷들. `{user_id}/…` 하나만 훑으면 된다. */
+const USER_PREFIXED_BUCKETS: ReadonlyArray<string> = ['avatars', 'post-images'];
+
+/** 채팅 사진만 `{room_id}/{user_id}/…`라 방 번호를 먼저 알아내야 한다(0008). */
+const CHAT_IMAGE_BUCKET = 'chat-images';
+
+/** storage.list의 기본 상한이 100이다. 그 이상은 offset으로 넘긴다. */
+const LIST_PAGE_SIZE = 100;
+
+type ChatRoomRow = {
+  id: number;
+};
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...CORS_HEADERS, 'content-type': 'application/json' },
+  });
+}
+
+/**
+ * 한 폴더 안의 파일 경로를 모두 모은다.
+ *
+ * 폴더는 `id`가 null로 온다. 우리 경로는 어느 버킷에서든 여기서 한 겹 더 들어가지 않으므로
+ * 걸러내기만 하면 된다. 목록을 못 읽어도 조용히 넘어간다 — 뒷정리라서 그렇다.
+ */
+async function listFilePaths(
+  client: SupabaseClient,
+  bucket: string,
+  prefix: string,
+): Promise<string[]> {
+  const paths: string[] = [];
+  let offset = 0;
+
+  for (;;) {
+    const { data, error } = await client.storage
+      .from(bucket)
+      .list(prefix, { limit: LIST_PAGE_SIZE, offset });
+
+    if (error !== null || data === null) {
+      break;
+    }
+
+    for (const entry of data) {
+      if (entry.id === null) {
+        continue;
+      }
+      paths.push(`${prefix}/${entry.name}`);
+    }
+
+    if (data.length < LIST_PAGE_SIZE) {
+      break;
+    }
+    offset += LIST_PAGE_SIZE;
+  }
+
+  return paths;
+}
+
+/** 내가 사고팔던 방 번호. 행이 살아 있는 동안에만 알 수 있어 삭제 전에 읽어 둔다. */
+async function fetchRoomIds(client: SupabaseClient, userId: string): Promise<number[]> {
+  const { data, error } = await client
+    .from('chat_rooms')
+    .select('id')
+    .or(`buyer_id.eq.${userId},seller_id.eq.${userId}`);
+
+  if (error !== null || data === null) {
+    return [];
+  }
+
+  return (data as ChatRoomRow[]).map(function toId(row: ChatRoomRow): number {
+    return row.id;
+  });
+}
+
+/** 버킷 하나를 비운다. 실패해도 던지지 않는다 — 계정은 이미 지워졌고 남는 것은 파일뿐이다. */
+async function removeFiles(
+  client: SupabaseClient,
+  bucket: string,
+  paths: string[],
+): Promise<void> {
+  if (paths.length === 0) {
+    return;
+  }
+
+  await client.storage.from(bucket).remove(paths);
+}
+
+async function removeUserFiles(
+  client: SupabaseClient,
+  userId: string,
+  roomIds: number[],
+): Promise<void> {
+  for (const bucket of USER_PREFIXED_BUCKETS) {
+    const paths = await listFilePaths(client, bucket, userId);
+    await removeFiles(client, bucket, paths);
+  }
+
+  // 방을 통째로 비우지 않는다. 같은 방에 상대가 올린 사진이 함께 들어 있다.
+  for (const roomId of roomIds) {
+    const paths = await listFilePaths(client, CHAT_IMAGE_BUCKET, `${roomId}/${userId}`);
+    await removeFiles(client, CHAT_IMAGE_BUCKET, paths);
+  }
+}
+
+Deno.serve(async function handleDeleteAccount(request: Request): Promise<Response> {
+  if (request.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: CORS_HEADERS });
+  }
+
+  if (request.method !== 'POST') {
+    return jsonResponse({ error: 'Method not allowed' }, 405);
+  }
+
+  const authorization = request.headers.get('Authorization');
+  if (authorization === null) {
+    return jsonResponse({ error: '로그인이 필요합니다.' }, 401);
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const anonKey = Deno.env.get('SUPABASE_ANON_KEY');
+  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+  if (
+    supabaseUrl === undefined ||
+    anonKey === undefined ||
+    serviceRoleKey === undefined
+  ) {
+    return jsonResponse({ error: '서버 설정이 올바르지 않습니다.' }, 500);
+  }
+
+  // 클라이언트를 둘 만든다. 앞의 것은 "누가 보냈는가"만 판단하고(anon 키 + 그 사람의 토큰),
+  // 뒤의 것만 지운다. 하나로 합치면 service_role 권한으로 신원을 확인하는 셈이라
+  // 토큰이 잘못돼도 통과하는 길이 생길 수 있다.
+  const caller = createClient(supabaseUrl, anonKey, {
+    global: { headers: { Authorization: authorization } },
+    auth: { persistSession: false },
+  });
+
+  const { data: userData, error: userError } = await caller.auth.getUser();
+  if (userError !== null || userData.user === null) {
+    return jsonResponse({ error: '로그인이 만료되었습니다. 다시 로그인해 주세요.' }, 401);
+  }
+
+  const userId = userData.user.id;
+  const admin = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false },
+  });
+
+  const roomIds = await fetchRoomIds(admin, userId);
+
+  // 순서가 중요하다. 파일을 먼저 지우면 삭제가 실패했을 때 사진만 사라진 계정이 남는다.
+  // 계정을 먼저 지우면 실패 시 남는 것은 아무도 안 보는 파일뿐이다.
+  const { error: deleteError } = await admin.auth.admin.deleteUser(userId);
+  if (deleteError !== null) {
+    return jsonResponse({ error: deleteError.message }, 500);
+  }
+
+  await removeUserFiles(admin, userId, roomIds);
+
+  return jsonResponse({ ok: true }, 200);
+});

--- a/todo.md
+++ b/todo.md
@@ -171,14 +171,21 @@
 
 ## 8단계 — 계정
 
-### 8-1. 비밀번호 변경 · 회원탈퇴
+### 8-1. 비밀번호 변경 · 회원탈퇴 ✅ 완료 (2026-08-05)
+
+구현 노트는 `note.md`의 "계정 — 비밀번호 변경 · 회원탈퇴", 밟기 전에 확인한 함정은
+`troble.md`의 같은 절에 있다.
 
 - **현황**: `feature.md` §1 요구사항인데 미구현. `profileSettingsForm`은 닉네임·아바타만 다룬다.
-- **설계**: 비밀번호 변경은 `supabase.auth.updateUser`로 간단하다(이메일 회원만 — 구글 로그인
-  사용자에게는 감춘다). **탈퇴는 `service_role`이 필요해 이 프로젝트의 첫 Edge Function이 된다**
-  (`supabase/functions/delete-account/`). FK가 대부분 `on delete cascade`라 행은 따라 지워지지만
-  Storage 파일은 안 지워지므로 함수 안에서 직접 정리한다.
-- **마이그레이션**: 없음 (Edge Function 신설)
+- **한 것**: `/settings/account` 신설(마이페이지 메뉴 맨 아래). 비밀번호 변경은
+  `updateUser`로 간단하다고 적어 뒀지만 **그것만으로는 현재 비밀번호를 아무도 검사하지 않아서**
+  `signInWithPassword`로 본인 확인을 한 번 거친 뒤 바꾼다. 폼을 감출지 말지는
+  `app_metadata.provider`(마지막 로그인 방법)가 아니라 `identities`로 판단해야 한다
+  (troble.md 같은 절 1·2번). 탈퇴는 예정대로 첫 Edge Function이 됐고, 지울 사람은
+  몸통이 아니라 **요청에 실린 토큰이 정한다**. 확인 문구(`탈퇴합니다`)를 적어야 열린다.
+- **마이그레이션**: 없음 (Edge Function 신설 — `supabase functions deploy delete-account`)
+- **주의**: 스토리지 뒷정리에서 `chat-images`만 경로가 `{room_id}/{user_id}/…`라
+  사용자 접두사로 훑을 수 없다. 삭제 전에 방 번호를 읽어 둔다(troble.md 같은 절 5번).
 
 ### 8-2. 카카오 로그인
 

--- a/troble.md
+++ b/troble.md
@@ -1418,3 +1418,123 @@ jest.mock('../api/notificationApi', function mockNotificationApi() {
 상수 파일로 옮기면 커서 유틸이 API를 import할 이유가 사라진다. 이번에는 기존 셋(`chatCursor`,
 `postSearchCursor`, `myPostCursor`)과 모양을 맞추는 쪽을 골랐지만, 다음에 네 번째가 생기면
 그때는 옮기는 편이 낫다.
+
+## 계정 — 비밀번호 변경 · 회원탈퇴 (2026-08-05)
+
+이 절의 다섯 가지는 모두 **밟기 전에 확인한 함정이다.** 화면이 죽는 종류가 아니라
+"동작은 하는데 뜻이 다른" 종류라, 만들고 나서는 눈에 띄지 않았을 것들이다.
+
+### 1. `updateUser({ password })`는 현재 비밀번호를 묻지 않는다
+
+**증상**: 비밀번호 변경 폼에 "현재 비밀번호" 칸을 두고 그 값을 아무 데도 쓰지 않아도
+비밀번호가 바뀐다. 칸이 있으니 확인하는 것처럼 보이지만 **검사하는 사람이 없다.**
+
+**원인**: `supabase.auth.updateUser`는 지금 세션이 유효한지만 본다. 카페에 열어 둔 브라우저,
+공용 PC의 로그인 상태 하나면 계정을 통째로 가져갈 수 있다는 뜻이다.
+
+Supabase에 "Secure password change"(변경 시 재인증 요구) 설정이 있지만 대시보드 스위치라
+코드에는 흔적이 남지 않는다. 개발 편의로 꺼 둔 Confirm email과 같은 종류의 위험이다 —
+대시보드 상태에 기대면 배포 때 잊는다.
+
+**해결**: 바꾸기 전에 그 비밀번호로 실제 로그인해 본다.
+
+```ts
+const { error: signInError } = await supabase.auth.signInWithPassword({
+  email: input.email, password: input.currentPassword,
+});
+if (signInError !== null) throw signInError;   // → "현재 비밀번호가 올바르지 않습니다."
+```
+
+덕분에 오류 매핑에서 `invalid_credentials`의 뜻이 이 화면에서만 달라진다. 로그인 화면에서는
+"이메일 또는 비밀번호가 올바르지 않습니다"지만 여기서는 이메일이 세션에서 온 값이라 틀릴 수가
+없다 — 그래서 `accountErrorMessage`는 같은 코드를 "현재 비밀번호가 올바르지 않습니다"로 읽는다.
+
+### 2. `app_metadata.provider`로 판단하면 이메일 가입자의 비밀번호 변경이 사라진다
+
+**증상**: 이메일로 가입한 사람이 구글로 한 번 로그인하면, 그 뒤로 계정 설정에서
+비밀번호 변경 칸이 통째로 없어진다. 비밀번호는 그대로 살아 있는데 바꿀 길만 없다.
+
+**원인**: `app_metadata.provider`는 계정의 로그인 방법이 아니라 **마지막으로 로그인한 방법**이다.
+같은 이메일로 구글을 이어 붙이면 identity가 둘이 되지만 `provider`는 하나만 가리킨다.
+
+**해결**: `user.identities` 배열을 본다. 한 계정에 붙은 로그인 방법 전부가 여기 있다.
+
+```ts
+return identities.some(function isPasswordIdentity(identity): boolean {
+  return identity.provider === 'email';
+});
+```
+
+`app_metadata`는 identities가 없는 응답일 때의 차선책으로만 남겼다. 단위 테스트에
+"구글로 마지막에 로그인했어도 이메일 identity가 남아 있으면 바꿀 수 있다"를 넣어 둔 이유다.
+
+### 3. 탈퇴 직후의 `signOut()`은 실패하고, 죽은 토큰이 남는다
+
+**증상**: 계정을 지운 뒤 평소처럼 로그아웃하면 401이 돌아온다. 계정이 없으니 당연하다.
+문제는 **supabase-js가 서버 응답이 실패하면 저장소의 토큰을 지우지 않는다**는 것이다.
+새로고침하면 이미 없는 사람의 세션으로 화면이 다시 서고, 첫 요청에서야 무너진다.
+
+**원인**: 기본 `scope: 'global'`은 서버에 "이 사용자의 세션을 모두 끊어라"라고 말한다.
+지울 사용자가 없으면 그 말이 실패하고, 실패한 로그아웃은 로컬 정리까지 건너뛴다.
+
+**해결**: 서버에 알리지 않고 이 기기의 토큰만 지운다.
+
+```ts
+// authApi.signOutLocally — 탈퇴 직후 전용
+await supabase.auth.signOut({ scope: 'local' });
+```
+
+로그아웃(`useSignOutMutation`)은 그대로 `global`을 쓴다. 그쪽은 계정이 살아 있어
+다른 기기의 세션까지 끊는 것이 맞다.
+
+### 4. Edge Function이 적어 보낸 이유가 화면까지 오지 않는다
+
+**증상**: 함수가 `{ "error": "로그인이 만료되었습니다. 다시 로그인해 주세요." }`를 401로
+돌려줘도 화면에는 `Edge Function returned a non-2xx status code`만 뜬다.
+
+**원인**: `functions.invoke`는 2xx가 아니면 `FunctionsHttpError`를 만들어 주고 **본문은 읽지
+않는다.** 응답은 `error.context`(Response)에 그대로 들어 있지만 아무도 열어 보지 않는 상태다.
+
+**해결**: 던지기 전에 본문을 열어 우리가 적어 보낸 문구를 꺼낸다.
+
+```ts
+if (error instanceof FunctionsHttpError) {
+  const body: unknown = await error.context.json();   // JSON이 아니면 catch로 흘린다
+  ...
+}
+```
+
+꺼내지 못하면 원래 오류를 그대로 던진다. 그때는 `accountErrorMessage`의 `non-2xx` 패턴이
+"탈퇴 요청이 서버에 닿지 못했습니다"로 받는다 — **함수를 아직 배포하지 않은 상태**가
+정확히 이 경로로 떨어진다.
+
+### 5. 스토리지는 `on delete cascade`를 타지 않는다 — 게다가 채팅 사진만 경로가 다르다
+
+**증상**: 탈퇴하면 DB는 깨끗해지는데(0001의 FK가 전부 cascade다) 버킷에는 사진이 그대로 남는다.
+아무 행도 가리키지 않아 다시 찾을 방법도 없는 파일이다.
+
+**원인**: `storage.objects`는 `profiles`를 참조하지 않는다. 파일과 행을 잇는 것은
+`posts.thumbnail_url` 같은 문자열뿐이라 FK가 따라갈 길이 없다.
+
+여기까지는 예상한 일이고, 실제로 걸린 것은 **버킷마다 경로 규칙이 다르다**는 쪽이었다.
+
+| 버킷 | 경로 | 사용자 접두사로 훑을 수 있나 |
+| --- | --- | --- |
+| `avatars` (0002) | `{user_id}/{stamp}.ext` | 된다 |
+| `post-images` (0005) | `{user_id}/{stamp}-{i}.ext` | 된다 |
+| `chat-images` (0008) | `{room_id}/{user_id}/…` | **안 된다** |
+
+0008이 채팅 사진의 첫 칸을 방으로 둔 것은 storage 정책이 "이 방 사람인가"를 봐야 했기 때문이다.
+그 판단은 지금도 옳지만, 덕분에 "이 사람의 파일"을 접두사 하나로 모을 수 없다.
+
+**해결**: 삭제 **전에** `chat_rooms`에서 내 방 번호를 읽어 둔다. 행이 사라진 뒤에는 알 길이 없다.
+
+```ts
+const roomIds = await fetchRoomIds(admin, userId);          // 삭제 전
+await admin.auth.admin.deleteUser(userId);
+await removeUserFiles(admin, userId, roomIds);              // {room_id}/{user_id} 만 지운다
+```
+
+방을 통째로 비우지 않는다 — 같은 폴더에 상대가 올린 사진이 함께 들어 있다.
+`storage.list`가 기본 100개까지만 주는 것도 여기서 걸린다. 사진 100장을 넘긴 사용자의
+나머지가 조용히 남지 않도록 `offset`으로 끝까지 넘긴다.


### PR DESCRIPTION
`todo.md` 8단계 8-1. 앞 일곱 단계와 달리 **DB에 미리 깔려 있던 것이 없는 자리**다.
`auth.users`는 우리 스키마가 아니라 GoTrue의 것이라 마이그레이션으로 손댈 곳이 없고,
대신 이 프로젝트의 **첫 Edge Function**이 생겼다.

## 비밀번호 변경 (`/settings/account`)

`supabase.auth.updateUser({ password })`는 **지금 세션만 있으면 통과한다** — 현재 비밀번호를
묻지 않는다. 남이 열어 둔 브라우저 하나면 계정을 가져갈 수 있다는 뜻이라, 바꾸기 전에
`signInWithPassword`로 본인인지 한 번 확인한다. 대시보드의 "Secure password change" 설정에
기대지 않은 이유는 코드만 보고는 켜져 있는지 알 수 없어서다.

폼을 감출지 말지는 `user.identities`로 판단한다. `app_metadata.provider`는 계정의 로그인 방법이
아니라 **마지막으로 로그인한 방법**이라, 그것으로 보면 이메일 가입자가 구글로 한 번 들어온 뒤
비밀번호 변경 칸이 통째로 사라진다.

| 계정 | 폼 |
| --- | --- |
| 이메일 가입 | 보임 |
| 구글만 | 안 보임 (안내 문구) |
| 이메일 + 구글 연결 | 보임 |
| 이메일 가입자가 마지막에 구글로 로그인 | 보임 |

## 회원탈퇴 (`supabase/functions/delete-account`)

`auth.admin.deleteUser`가 `service_role`을 요구하고 그 키는 브라우저에 둘 수 없어 서버로 나간다.
**지울 사람은 몸통이 아니라 요청에 실린 토큰이 정한다** — 몸통으로 id를 받으면 남의 id를 적어
보내는 길이 열린다. 함수 안에서도 클라이언트를 둘 만들어 앞의 것(anon + 사용자 토큰)은 신원만
판단하고 뒤의 것(service_role)만 지운다.

DB는 손대지 않는다. 0001의 FK가 전부 `on delete cascade`라 `auth.users` 한 행이 사라지면
profiles 이하가 따라 지워진다. **따라오지 않는 것은 스토리지뿐**이고 그 뒷정리가 함수의 나머지 일이다.

| 버킷 | 경로 | 사용자 접두사로 훑을 수 있나 |
| --- | --- | --- |
| `avatars` | `{user_id}/…` | 된다 |
| `post-images` | `{user_id}/…` | 된다 |
| `chat-images` | `{room_id}/{user_id}/…` | **안 된다** → 삭제 전에 방 번호를 읽어 둔다 |

순서는 계정 먼저, 파일 나중이다. 반대로 하면 삭제가 실패했을 때 "사진만 사라진 계정"이 남는다.

UI는 확인 문구(`탈퇴합니다`)를 적어야 버튼이 열리고 무엇이 사라지는지 그 자리에 나열한다.
차단·게시물 삭제와 달리 돌아올 곳이 없어 "한 번 더 누르기"로는 모자라다고 봤다.

탈퇴 직후 로그아웃은 `scope: 'local'`이다. 계정이 없어 global signOut이 401로 실패하는데,
실패하면 supabase-js가 저장소의 토큰을 남겨 새로고침 때 죽은 세션으로 다시 선다.

## 변경 파일

```
supabase/functions/delete-account/index.ts   (신규 — 첫 Edge Function)
src/features/account/                        (신규 폴더)
  api/accountApi.ts · hooks/useAccountMutations.ts
  utils/passwordLogin.ts · validatePasswordChange.ts · accountErrorMessage.ts
  components/accountSettingsPage · passwordChangeForm · deleteAccountSection
src/features/auth/api/authApi.ts             signOutLocally 추가
src/app/router.tsx                           /settings/account
src/features/profile/components/myPageMenu   계정 설정 항목
note.md · troble.md · todo.md
```

## 검증

- `npx jest` **81 스위트 · 563건 통과** (신규 4 스위트 21건)
- `tsc --noEmit` · `eslint` 무경고, `vite build` 성공
- Edge Function `delete-account` v1 배포(ACTIVE, `verify_jwt: true`).
  `OPTIONS` → 204 + CORS 헤더, 토큰 없는 `POST` → 401 `UNAUTHORIZED_NO_AUTH_HEADER`.
  걱정하던 "verify_jwt가 preflight까지 막지 않나"는 게이트웨이가 OPTIONS를 통과시켜 해소됐다.

**실제 계정 삭제까지는 확인하지 못했다.** 지워도 되는 계정과 그 사람의 토큰이 필요해서다.
머지 전에 시험 계정으로 한 번 밟아 보는 것이 남은 검증이다 — 탈퇴 후 로그인 화면으로 밀려나는지,
그 이메일로 다시 가입되는지, 버킷에 파일이 남지 않았는지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
