### PR TITLE
fix : Realtime 채널 이름이 겹쳐 화면이 죽는 문제

### DIFF
--- a/src/features/chat/api/chatApi.ts
+++ b/src/features/chat/api/chatApi.ts
@@ -1,4 +1,5 @@
 import { supabase } from '../../../shared/lib/supabaseClient';
+import { uniqueChannelTopic } from '../../../shared/utils/uniqueChannelTopic';
 import type { PostStatus } from '../../post/types';
 import type {
   ChatMessage,
@@ -367,7 +368,7 @@ export function subscribeToRoomMessages(
   onReady: () => void,
 ): () => void {
   const channel = supabase
-    .channel(`chat-room-${roomId}`)
+    .channel(uniqueChannelTopic(`chat-room-${roomId}`))
     .on(
       'postgres_changes',
       { event: 'INSERT', schema: 'public', table: 'messages', filter: `room_id=eq.${roomId}` },
@@ -398,10 +399,13 @@ export function subscribeToRoomMessages(
  *
  * 필터를 걸 수 없다 — "내가 참여한 방"은 컬럼 하나로 표현되지 않는다.
  * 대신 chat_rooms_select 정책이 남의 방을 흘려보내지 않는다. Realtime도 RLS를 그대로 탄다.
+ *
+ * 이 구독은 두 곳이 동시에 건다 — 늘 떠 있는 탭바 배지(useUnreadChatCount)와 채팅 목록 화면이다.
+ * 이름이 고정이면 둘째가 첫째의 채널을 그대로 받아 죽으므로 번호를 붙인다(uniqueChannelTopic).
  */
 export function subscribeToMyChatRooms(onChange: () => void): () => void {
   const channel = supabase
-    .channel('chat-rooms')
+    .channel(uniqueChannelTopic('chat-rooms'))
     .on(
       'postgres_changes',
       { event: '*', schema: 'public', table: 'chat_rooms' },

--- a/src/features/notification/api/notificationApi.ts
+++ b/src/features/notification/api/notificationApi.ts
@@ -1,4 +1,5 @@
 import { supabase } from '../../../shared/lib/supabaseClient';
+import { uniqueChannelTopic } from '../../../shared/utils/uniqueChannelTopic';
 import type { AppNotification, NotificationCursor, NotificationType } from '../types';
 
 /** 알림 한 페이지 크기. 서버(0015)가 50으로 한 번 더 막는다. */
@@ -125,10 +126,13 @@ export async function markAllNotificationsRead(): Promise<void> {
  *
  * supabase를 아는 자리를 api/ 한 곳에 가둬 두는 규칙은 여기도 같다 — 훅이 직접 채널을 열면
  * 화면 테스트가 import.meta에 닿아 로드 단계에서 죽는다(troble.md #5).
+ *
+ * 이름에 번호를 붙이는 이유는 채팅방 목록과 같다 — 헤더의 알림 종과 알림 화면이 함께 뜨는
+ * 순간 둘이 같은 채널을 집게 된다(uniqueChannelTopic). viewerId만으로는 갈리지 않는다.
  */
 export function subscribeToMyNotifications(viewerId: string, onInsert: () => void): () => void {
   const channel = supabase
-    .channel(`notifications-${viewerId}`)
+    .channel(uniqueChannelTopic(`notifications-${viewerId}`))
     .on(
       'postgres_changes',
       {

--- a/src/shared/utils/uniqueChannelTopic.test.ts
+++ b/src/shared/utils/uniqueChannelTopic.test.ts
@@ -1,0 +1,23 @@
+import { uniqueChannelTopic } from './uniqueChannelTopic';
+
+describe('uniqueChannelTopic', function uniqueChannelTopicSuite() {
+  it('같은 앞부분으로 불러도 매번 다른 이름이 나온다', function neverRepeatsCase() {
+    const first = uniqueChannelTopic('chat-rooms');
+    const second = uniqueChannelTopic('chat-rooms');
+
+    expect(first).not.toBe(second);
+  });
+
+  // 앞부분을 남기는 것이 이 함수의 목적 절반이다. 개발자 도구에서 어느 구독인지 읽혀야 한다.
+  it('앞부분은 그대로 남는다', function keepsPrefixCase() {
+    expect(uniqueChannelTopic('notifications-abc')).toMatch(/^notifications-abc#/);
+  });
+
+  // 앞부분이 달라도 번호는 하나의 흐름에서 나온다 — 서로 다른 구독끼리도 겹치지 않는다.
+  it('앞부분이 달라도 서로 겹치지 않는다', function acrossPrefixesCase() {
+    const room = uniqueChannelTopic('chat-room-1');
+    const rooms = uniqueChannelTopic('chat-room-1');
+
+    expect(new Set([room, rooms]).size).toBe(2);
+  });
+});

--- a/src/shared/utils/uniqueChannelTopic.ts
+++ b/src/shared/utils/uniqueChannelTopic.ts
@@ -1,0 +1,27 @@
+/** 이 페이지가 열린 뒤 만들어진 채널 수. 새로고침하면 0부터 다시 센다. */
+let channelSequence = 0;
+
+/**
+ * 겹치지 않는 Realtime 채널 이름을 만든다.
+ *
+ * supabase-js의 `supabase.channel(topic)`은 **같은 이름의 채널이 이미 있으면 그것을 그대로
+ * 돌려준다**(RealtimeClient.channel). 새로 만들어 주는 것이 아니다. 그래서 이름을 고정해 두면
+ * 두 번째로 부른 쪽이 남이 이미 `subscribe()`까지 마친 채널을 받아 들고,
+ * 거기에 `.on('postgres_changes', …)`를 걸다가 예외로 죽는다.
+ *
+ *   cannot add `postgres_changes` callbacks for realtime:chat-rooms after `subscribe()`.
+ *
+ * 이름이 겹치는 것은 사고가 아니라 설계였다 — 탭바 배지(useUnreadChatCount)와 채팅 목록
+ * 화면이 같은 방 목록을 보므로 둘 다 같은 구독을 건다. 헤더의 알림 종과 알림 화면도 같다.
+ * 한쪽이 늘 떠 있는 것들이라 다른 쪽으로 이동하는 순간 반드시 부딪힌다.
+ *
+ * 이름 뒤에 번호를 붙여 매번 새 채널을 받게 한다. topic은 클라이언트가 채널을 구분하려고
+ * 쓰는 이름일 뿐이고, 서버가 무엇을 보내 줄지는 `.on()`에 넘긴 조건이 정한다 —
+ * 이름이 달라도 받는 것은 같다.
+ *
+ * 앞부분(prefix)은 그대로 남긴다. 개발자 도구에서 채널 목록을 볼 때 어느 구독인지 읽히게 하려는 것이다.
+ */
+export function uniqueChannelTopic(prefix: string): string {
+  channelSequence += 1;
+  return `${prefix}#${channelSequence}`;
+}

--- a/troble.md
+++ b/troble.md
@@ -1737,3 +1737,61 @@ select count(*) from comments where post_id = v_post;   -- 이제 B로서 읽는
 여덟 가지를 한 번에 밟았다 — 차단 전/후 양방향, 판매자 차단 후 쓰기(42501), 판매자의
 남의 댓글 삭제(1행), 제3자의 삭제(0행), 공백 댓글(23514). **⑦의 "0행"이 특히 이 방법이라야
 잡힌다** — RLS로 막힌 delete는 오류가 아니라 조용히 0행이라, 예외만 보고 있으면 통과한 줄 안다.
+
+## 채널 이름이 겹쳐 화면이 죽는다 (2026-08-05)
+
+### 1. `supabase.channel(이름)`은 새 채널을 만들어 주지 않는다
+
+**증상**: 채팅 목록으로 가면 화면이 통째로 죽었다.
+
+```
+cannot add `postgres_changes` callbacks for realtime:chat-rooms after `subscribe()`.
+  at subscribeToMyChatRooms (chatApi.ts)
+  at subscribeToRooms (useChatRealtime.ts)
+```
+
+**원인**: 이름을 보고 "새 채널"이라고 읽었는데 아니었다. `RealtimeClient.channel(topic)`은
+같은 이름이 이미 있으면 **그것을 그대로 돌려준다.**
+
+```js
+const exists = this.getChannels().find((c) => c.topic === realtimeTopic);
+if (!exists) { … return chan; } else { return exists; }
+```
+
+그래서 둘째로 부른 쪽은 남이 이미 `subscribe()`까지 마친 채널을 받아 들고, 거기에 `.on()`을
+건다. `RealtimeChannel.on`은 채널이 joined/joining이면 예외를 던진다 — 이미 서버와 맞춰 둔
+구독 조건에 뒤늦게 하나 더 얹을 수 없기 때문이다.
+
+**해결**: 이름 뒤에 일련번호를 붙여 매번 새 채널을 받는다(`uniqueChannelTopic`).
+topic은 클라이언트가 채널을 구분하려고 쓰는 이름일 뿐이고, 서버가 무엇을 보낼지는
+`.on()`에 넘긴 조건이 정한다 — 이름이 달라도 받는 것은 같다.
+
+### 2. 겹친 것은 사고가 아니라 설계였다
+
+**증상**: "어디서 두 번 부르지" 하고 중복 호출을 찾았는데 없었다. 부르는 곳은 각자 한 번씩이다.
+
+**원인**: `useChatRoomsRealtime`을 거는 곳이 **둘 다 맞다.**
+
+- `useUnreadChatCount` — 탭바 배지. 늘 떠 있다.
+- `chatRoomListPage` — 채팅 목록 화면.
+
+같은 방 목록을 보므로 같은 구독을 거는 것이 당연하고, 한쪽이 늘 떠 있으므로 다른 쪽으로
+이동하는 순간 **반드시** 부딪힌다. 우연히 겹치는 게 아니라 그 화면에 들어가면 100% 죽는다.
+
+**해결**: 같은 짝이 알림에도 있었다 — `notificationBellLink`(헤더)와 `notificationPage`다.
+증상은 채팅에서만 봤지만 알림 화면도 같은 이유로 죽는 상태였다. 세 곳을 한꺼번에 고쳤다.
+
+`notifications-${viewerId}`처럼 이름에 id를 넣어 둔 것이 방어가 되어 주지 않는다 —
+갈라지는 것은 **사용자**인데 겹치는 것은 **같은 사용자의 두 화면**이다.
+
+### 3. 테스트가 넉넉히 통과하는데도 죽어 있었다
+
+**증상**: 84 스위트 581건이 다 통과하는 상태에서 화면은 열리지 않았다.
+
+**원인**: 화면 테스트는 `chatApi`·`notificationApi`를 통째로 mock한다(troble.md #5의 `import.meta`
+때문이다). mock한 함수는 채널을 열지 않으므로 이 충돌이 일어날 자리가 없다.
+Realtime 구독은 **api를 mock하는 순간 시험 범위 밖으로 나간다.**
+
+**해결**: 이번 것은 `uniqueChannelTopic`을 순수 함수로 떼어 내 그 부분만 단위 시험으로 묶었다.
+다만 "두 화면이 같은 구독을 건다"는 조합 자체는 여전히 시험이 잡지 못한다 —
+같은 훅을 두 곳에서 거는 것을 새로 만들 때는 화면을 직접 열어 봐야 한다.


### PR DESCRIPTION
## 증상

채팅 목록으로 들어가면 화면이 통째로 죽는다.

```
cannot add `postgres_changes` callbacks for realtime:chat-rooms after `subscribe()`.
  at subscribeToMyChatRooms (chatApi.ts)
  at subscribeToRooms (useChatRealtime.ts)
```

## 원인

`supabase.channel(이름)`을 "새 채널을 만든다"로 읽었는데 아니다. 같은 이름이 이미 있으면 **그것을 그대로 돌려준다.**

```js
const exists = this.getChannels().find((c) => c.topic === realtimeTopic);
if (!exists) { … return chan; } else { return exists; }
```

그래서 둘째로 부른 쪽은 남이 이미 `subscribe()`까지 마친 채널을 받아 들고, 거기에 `.on()`을 건다. `RealtimeChannel.on`은 채널이 joined/joining이면 예외를 던진다.

**이름이 겹치는 것은 사고가 아니라 설계였다.** `useChatRoomsRealtime`을 거는 곳이 둘 다 맞다 — 늘 떠 있는 탭바 배지(`useUnreadChatCount`)와 채팅 목록 화면이다. 같은 방 목록을 보므로 같은 구독을 거는 것이 당연하고, 한쪽이 늘 떠 있으므로 다른 쪽으로 이동하면 **반드시** 부딪힌다. 우연이 아니라 그 화면에 들어가면 100%다.

같은 짝이 알림에도 있었다 — `notificationBellLink`(헤더)와 `notificationPage`. 증상은 채팅에서만 봤지만 알림 화면도 같은 이유로 죽는 상태였다. `notifications-${viewerId}`처럼 id를 넣어 둔 것은 방어가 되지 않는다. 갈라지는 것은 **사용자**인데 겹치는 것은 **같은 사용자의 두 화면**이다.

## 고친 것

`uniqueChannelTopic(prefix)` — 이름 뒤에 일련번호를 붙여 매번 새 채널을 받는다.

topic은 클라이언트가 채널을 구분하려고 쓰는 이름일 뿐이고, 서버가 무엇을 보낼지는 `.on()`에 넘긴 조건이 정한다. 이름이 달라도 받는 것은 같다. 앞부분은 남겨 개발자 도구에서 어느 구독인지 읽히게 했다.

세 곳에 적용했다.

| 자리 | 전 | 후 |
| --- | --- | --- |
| `subscribeToRoomMessages` | `chat-room-42` | `chat-room-42#1` |
| `subscribeToMyChatRooms` | `chat-rooms` | `chat-rooms#2` |
| `subscribeToMyNotifications` | `notifications-<uid>` | `notifications-<uid>#3` |

## 시험이 못 잡은 이유

84 스위트 581건이 다 통과하는 상태에서 화면이 죽어 있었다. 화면 테스트는 `chatApi`·`notificationApi`를 통째로 mock하므로(`import.meta` 때문이다) 채널을 여는 자리 자체가 없다. **Realtime 구독은 api를 mock하는 순간 시험 범위 밖으로 나간다.**

이번 것은 `uniqueChannelTopic`을 순수 함수로 떼어 그 부분만 묶었다. 다만 "두 화면이 같은 구독을 건다"는 조합은 여전히 시험이 잡지 못한다 — `troble.md`에 적어 두었다.

## 확인

- `tsc --noEmit` · `eslint` 무경고
- `jest` 84 스위트 581건 통과
- `vite build` 성공
- 마이그레이션 없음 (클라이언트만)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

