### PR TITLE
chore : Vercel 배포 설정

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,11 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }],
+  "headers": [
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Vercel 배포에 필요한 설정 한 파일.

- **SPA 폴백** — 없으면 `/posts/12` 새로고침이나 직접 링크 진입이 404가 난다. 경로는 react-router가 맡으므로 모든 요청을 `index.html`로 보낸다.
- **`/assets` 1년 캐시** — Vite가 내용 해시로 파일명을 만들어서(`index-DrHvloXq.js`) 내용이 바뀌면 이름이 바뀐다. 그래서 immutable이 안전하고, 재방문자는 JS·CSS를 다시 받지 않는다.

빌드 확인: `dist/`에 `index.html`과 `assets/`가 나오는 것과 JSON 문법 모두 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)